### PR TITLE
Pass initial test suite

### DIFF
--- a/python/shark_turbine/dynamo/tensor.py
+++ b/python/shark_turbine/dynamo/tensor.py
@@ -40,6 +40,23 @@ from iree.runtime import (
 # Factories and device enablement
 ###############################################################################
 
+def get_itemsize(dtype: torch.dtype):
+    """
+    returns the torch datatype element size in bytes
+    """
+    if dtype in (torch.quint4x2, torch.uint8, torch.int8, torch.quint8, torch.qint8):
+        return 1
+    elif dtype in (torch.int16, torch.float16, torch.bfloat16):
+        return 2
+    elif dtype in (torch.int32, torch.qint32, torch.float32, torch.complex32):
+        return 4
+    elif dtype in (torch.int64, torch.float64, torch.complex64):
+        return 8
+    elif dtype == torch.complex128:
+        return 16
+
+    raise TypeError(f"Unknown torch datatype, {dtype}")
+
 
 class TurbineMode(TorchFunctionMode):
     """Enables PyTorch tensor device= support for Tensor factory functions.
@@ -280,7 +297,7 @@ def _normalize_size(size_or_nested) -> Sequence[int]:
 
 def _calculate_c_contig_size(size: Sequence[int], dtype: torch.dtype) -> int:
     """Calculates a C-contiguous buffer size in bytes for torch size and dtype."""
-    accum = dtype.itemsize
+    accum = get_itemsize(dtype)
     for s in size:
         accum *= s
     return accum


### PR DESCRIPTION
Allows retrieving the element size of a Tensor based on its datatype, this passes the initial test suite.