### PR TITLE
Parse list and scalar args for torch ops

### DIFF
--- a/python/shark_turbine/dynamo/importer.py
+++ b/python/shark_turbine/dynamo/importer.py
@@ -335,7 +335,7 @@ class GraphNodeImporter:
                 elif op == "output":
                     # args[0] is a singleton tuple that we flatten into multiple
                     # results.
-                    operands = [self._import_argument(arg) for arg in node.args[0]]
+                    operands = [self._import_argument(loc, arg) for arg in node.args[0]]
                     func_dialect.ReturnOp(operands, loc=loc)
 
     def _import_torch_op_overload(
@@ -379,10 +379,10 @@ class GraphNodeImporter:
         for i, parameter in enumerate(schema.arguments):
             if parameter.kwarg_only and parameter.name in node.kwargs:
                 # TODO: Nice error if KeyError.
-                operands.append(self._import_argument(node.kwargs[parameter.name], loc))
+                operands.append(self._import_argument(loc, node.kwargs[parameter.name]))
             elif i < len(node.args):
                 arg = node.args[i]
-                operands.append(self._import_argument(node.args[i], loc))
+                operands.append(self._import_argument(loc, node.args[i]))
             else:
                 operands.append(
                     self._import_default_value(
@@ -401,7 +401,7 @@ class GraphNodeImporter:
         for i, value in enumerate(operation.results):
             self._v[(node, i)] = value
 
-    def _import_argument(self, arg: NodeArgument, loc: Location = None) -> Value:
+    def _import_argument(self, loc: Location, arg: NodeArgument) -> Value:
         """Import an FX `Argument`, which must result to an MLIR `Value`."""
         if isinstance(arg, torch_fx.Node):
             # If implementing boxed support for multi-result nodes, then

--- a/python/shark_turbine/dynamo/importer.py
+++ b/python/shark_turbine/dynamo/importer.py
@@ -379,10 +379,10 @@ class GraphNodeImporter:
         for i, parameter in enumerate(schema.arguments):
             if parameter.kwarg_only and parameter.name in node.kwargs:
                 # TODO: Nice error if KeyError.
-                operands.append(self._import_argument(node.kwargs[parameter.name]))
+                operands.append(self._import_argument(node.kwargs[parameter.name], loc))
             elif i < len(node.args):
                 arg = node.args[i]
-                operands.append(self._import_argument(node.args[i]))
+                operands.append(self._import_argument(node.args[i], loc))
             else:
                 operands.append(
                     self._import_default_value(
@@ -401,7 +401,7 @@ class GraphNodeImporter:
         for i, value in enumerate(operation.results):
             self._v[(node, i)] = value
 
-    def _import_argument(self, arg: NodeArgument) -> Value:
+    def _import_argument(self, arg: NodeArgument, loc: Location = None) -> Value:
         """Import an FX `Argument`, which must result to an MLIR `Value`."""
         if isinstance(arg, torch_fx.Node):
             # If implementing boxed support for multi-result nodes, then
@@ -409,6 +409,29 @@ class GraphNodeImporter:
             if arg in self._multi_result_nodes:
                 raise RuntimeError(f"Attempt to de-reference a multi-result node")
             return self._v[(arg, 0)]
+        elif isinstance(arg, torch_fx.immutable_collections.immutable_list):
+            # create list operands
+            list_operands = []
+            for operand in arg:
+                if not isinstance(operand, type(arg[0])):
+                    raise TypeError(f"Lists with multiple types are not supported, got: {type(input[0])}, {type(operand)}")
+
+                val = self._import_default_value(loc, operand, SCALAR_TYPE_TO_TORCH_TYPE[type(operand)])
+                list_operands.append(val)
+
+            # construct list op
+            result_type = MlirType.parse(SCALAR_TYPE_TO_TORCH_LIST_TYPE[type(arg[0])], context=self._c)
+            operation = Operation.create(
+                "torch.prim.ListConstruct",
+                results=[result_type],
+                operands=list_operands,
+                loc=loc,
+            )
+            return operation.result
+        elif type(arg) in LITERAL_CONVERTER_MAP._cache:
+            with loc:
+                arg_value = LITERAL_CONVERTER_MAP.lookup(type(arg))(arg, self, self._cc)
+            return arg_value
         else:
             raise NotImplementedError(f"FIXME: Unsupported Node Argument: {arg}")
 
@@ -503,3 +526,15 @@ LITERAL_CONVERTER_MAP.map(
         "torch.constant.str", StringAttr.get(arg), cc.torch_str_type
     ).result,
 )
+
+SCALAR_TYPE_TO_TORCH_LIST_TYPE = {
+    int: "!torch.list<int>",
+    float: "!torch.list<float>",
+    str: "!torch.list<str>",
+}
+
+SCALAR_TYPE_TO_TORCH_TYPE = {
+    int: "!torch.int",
+    float: "!torch.float",
+    str: "!torch.str"
+}

--- a/python/test/dynamo/importer_basic_test.py
+++ b/python/test/dynamo/importer_basic_test.py
@@ -44,6 +44,41 @@ class ImportTests(unittest.TestCase):
 
         basic(torch.randn(3, 4))
 
+    def testImportVisionModule(self):
+        imp = FxImporter()
+
+        def import_compiler(gm: GraphModule, example_inputs):
+            gm.print_readable()
+            try:
+                imp.import_graph_module(gm)
+            finally:
+                print(imp.module)
+            imp.module.operation.verify()
+            return gm
+
+        backend = import_compiler
+        backend = aot_autograd(fw_compiler=backend)
+
+        from torch import nn
+        import torch.nn.functional as F
+        class ConvBlock(nn.Module):
+            def __init__(self, in_channels, out_channels, kernel_size=3, stride=1):
+                super(ConvBlock, self).__init__()
+                self.stride = stride
+                self.channel_pad = out_channels - in_channels
+                padding = (kernel_size - 1) // 2
+                self.convs = nn.Sequential(nn.Conv2d(in_channels=in_channels, out_channels=in_channels, kernel_size=kernel_size, stride=stride, padding=padding, groups=in_channels, bias=True), nn.Conv2d(in_channels=in_channels, out_channels=out_channels, kernel_size=1, stride=1, padding=0, bias=True))
+                self.act = nn.ReLU(inplace=True)
+
+            def forward(self, x):
+                h = x
+                if self.channel_pad > 0:
+                    x = F.pad(x, (0, 0, 0, 0, 0, self.channel_pad), 'constant', 0)
+                return self.act(self.convs(h) + x)
+
+        mod = ConvBlock(3,5)
+        opt_mod = torch.compile(mod, backend=backend)
+        opt_mod(torch.randn(1,3,256,256))
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
Resolves an issue with the `FxImporter` where arguments that are `!torch.list` types are not properly imported due to the Fx tracer denoting them via `immutable_list` types rather than encapsulating them in an `fx.Node`. Also addresses a case where a python scalar is not parsed into an `fx.Node` but rather retains its python type. For instance, in [`aten.convolution`](https://github.com/llvm/torch-mlir/blob/0109bf705b0dae3b4d55c7a9b180516787cbeac6/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td#L4583C18-L4583C18) where the "transposed" parameter is passed as false by default - this argument is left as a `bool` and therefore needs to be handled when importing arguments. 

