### PR TITLE
Import torch enum args

### DIFF
--- a/python/shark_turbine/dynamo/importer.py
+++ b/python/shark_turbine/dynamo/importer.py
@@ -123,8 +123,6 @@ TORCH_LAYOUT_TO_INT = {
     torch.sparse_bsc: 5,
 }
 
-TORCH_ENUM_TYPES = {torch.dtype, torch.layout, torch.memory_format}
-
 
 class FxImporter:
     """Main entry-point for importing an fx.GraphModule."""
@@ -487,8 +485,6 @@ class GraphNodeImporter:
                 loc=loc,
             )
             return operation.result
-        elif type(arg) in TORCH_ENUM_TYPES:
-            return self._import_enum_value(loc, arg)
         elif type(arg) in LITERAL_CONVERTER_MAP._cache:
             with loc:
                 arg_value = LITERAL_CONVERTER_MAP.lookup(type(arg))(arg, self, self._cc)
@@ -508,35 +504,6 @@ class GraphNodeImporter:
         # These all require an expected_jit_type to convert.
         # torch.dtype, torch.device, torch.memory_format, torch.layout
         # list
-
-    def _import_enum_value(self, loc: Location, arg):
-        """Import the correct integer representation of torch enum values"""
-        assert (
-            type(arg) in TORCH_ENUM_TYPES
-        ), f"Expected enum type to be one of {TORCH_ENUM_TYPES}, got {type(arg)}"
-        mapping = None
-        enum_cls = None
-
-        if isinstance(arg, torch.dtype):
-            mapping = TORCH_DTYPE_TO_INT
-            enum_cls = torch.dtype
-        elif isinstance(arg, torch.layout):
-            mapping = TORCH_LAYOUT_TO_INT
-            enum_cls = torch.layout
-        else:
-            mapping = TORCH_MEMORY_FORMAT_TO_INT
-            enum_cls = torch.layout
-
-        try:
-            int_repr = mapping[arg]
-        except KeyError:
-            raise TypeError(
-                f"Unsupported torch {enum_cls.__name__} expected one of {tuple(mapping.keys())}, but got {arg}"
-            )
-
-        with loc:
-            arg_value = LITERAL_CONVERTER_MAP.lookup(int)(int_repr, self, self._cc)
-        return arg_value
 
 
 class TypeSubclassMap:
@@ -621,6 +588,24 @@ LITERAL_CONVERTER_MAP.map(
     lambda arg, gni, cc: _make_constant_op(
         "torch.constant.device", StringAttr.get(str(arg)), cc.torch_device_type
     ).result,
+)
+LITERAL_CONVERTER_MAP.map(
+    torch.dtype,
+    lambda arg, gni, cc: LITERAL_CONVERTER_MAP.lookup(int)(
+        TORCH_DTYPE_TO_INT[arg], gni, cc
+    ),
+)
+LITERAL_CONVERTER_MAP.map(
+    torch.layout,
+    lambda arg, gni, cc: LITERAL_CONVERTER_MAP.lookup(int)(
+        TORCH_LAYOUT_TO_INT[arg], gni, cc
+    ),
+)
+LITERAL_CONVERTER_MAP.map(
+    torch.memory_format,
+    lambda arg, gni, cc: LITERAL_CONVERTER_MAP.lookup(int)(
+        TORCH_MEMORY_FORMAT_TO_INT[arg], gni, cc
+    ),
 )
 
 SCALAR_TYPE_TO_TORCH_LIST_TYPE = {

--- a/python/shark_turbine/dynamo/importer.py
+++ b/python/shark_turbine/dynamo/importer.py
@@ -115,7 +115,6 @@ TORCH_MEMORY_FORMAT_TO_INT = {
 
 # https://github.com/llvm/torch-mlir/blob/4c24472dea1c9102b898768b0b11e31487e50207/python/torch_mlir/_dynamo_fx_importer.py#L235
 TORCH_LAYOUT_TO_INT = {
-    # https://github.com/pytorch/pytorch/blob/master/torch/csrc/utils/tensor_layouts.cpp
     torch.strided: 0,
     torch.sparse_coo: 1,
     torch.sparse_csr: 2,
@@ -138,10 +137,10 @@ class FxImporter:
     ]
 
     def __init__(
-            self,
-            module: Optional[Module] = None,
-            context: Optional[Context] = None,
-            config_check: bool = True,
+        self,
+        module: Optional[Module] = None,
+        context: Optional[Context] = None,
+        config_check: bool = True,
     ):
         if module is not None:
             assert context is None, "If configuring with a Module, context must be None"
@@ -382,7 +381,7 @@ class GraphNodeImporter:
                     func_dialect.ReturnOp(operands, loc=loc)
 
     def _import_torch_op_overload(
-            self, loc: Location, node: torch_fx.Node, target: TorchOpOverload
+        self, loc: Location, node: torch_fx.Node, target: TorchOpOverload
     ):
         schema = target._schema
         assert isinstance(schema, FunctionSchema)
@@ -396,7 +395,8 @@ class GraphNodeImporter:
 
         # Intervening to use Scalar ops due to incorrect ops from AOT-autograd with scalar arguments.
         if mlir_op_name in TENSOR_SCALAR_OP_CONVERTER and (
-                isinstance(node.args[1], float) or isinstance(node.args[1], int)):
+            isinstance(node.args[1], float) or isinstance(node.args[1], int)
+        ):
             mlir_op_name = TENSOR_SCALAR_OP_CONVERTER[mlir_op_name]
 
         if not self._c.is_registered_operation(mlir_op_name):
@@ -511,7 +511,9 @@ class GraphNodeImporter:
 
     def _import_enum_value(self, loc: Location, arg):
         """Import the correct integer representation of torch enum values"""
-        assert type(arg) in TORCH_ENUM_TYPES, f"Expected enum type to be one of {TORCH_ENUM_TYPES}, got {type(arg)}"
+        assert (
+            type(arg) in TORCH_ENUM_TYPES
+        ), f"Expected enum type to be one of {TORCH_ENUM_TYPES}, got {type(arg)}"
         mapping = None
         enum_cls = None
 
@@ -528,14 +530,13 @@ class GraphNodeImporter:
         try:
             int_repr = mapping[arg]
         except KeyError:
-            raise TypeError(f"Unsupported torch {enum_cls.__name__} expected one of {tuple(mapping.keys())}, but got {arg}")
+            raise TypeError(
+                f"Unsupported torch {enum_cls.__name__} expected one of {tuple(mapping.keys())}, but got {arg}"
+            )
 
         with loc:
             arg_value = LITERAL_CONVERTER_MAP.lookup(int)(int_repr, self, self._cc)
         return arg_value
-
-
-
 
 
 class TypeSubclassMap:
@@ -575,7 +576,7 @@ class TypeSubclassMap:
 
 
 def _make_constant_op(
-        op_name: str, value_attr: MlirAttribute, result_type: Optional[MlirType] = None
+    op_name: str, value_attr: MlirAttribute, result_type: Optional[MlirType] = None
 ) -> Operation:
     return Operation.create(
         op_name,

--- a/python/shark_turbine/dynamo/tensor.py
+++ b/python/shark_turbine/dynamo/tensor.py
@@ -40,6 +40,7 @@ from iree.runtime import (
 # Factories and device enablement
 ###############################################################################
 
+
 class TurbineMode(TorchFunctionMode):
     """Enables PyTorch tensor device= support for Tensor factory functions.
 

--- a/python/test/dynamo/importer_basic_test.py
+++ b/python/test/dynamo/importer_basic_test.py
@@ -83,12 +83,15 @@ class ImportTests(unittest.TestCase):
         def foo():
             x = torch.ones_like(torch.randn(10), memory_format=torch.contiguous_format)
             x = torch.ones_like(torch.randn(10), memory_format=torch.preserve_format)
-            x = torch.ones_like(torch.randn(1,1,1,1), memory_format=torch.channels_last)
-            x = torch.ones_like(torch.randn(1,1,1,1,1), memory_format=torch.channels_last_3d)
+            x = torch.ones_like(
+                torch.randn(1, 1, 1, 1), memory_format=torch.channels_last
+            )
+            x = torch.ones_like(
+                torch.randn(1, 1, 1, 1, 1), memory_format=torch.channels_last_3d
+            )
 
         opt_foo = torch.compile(foo, backend=self.create_backend())
         opt_foo()
-
 
     def testImportVisionModule(self):
         from torch import nn

--- a/python/test/dynamo/importer_basic_test.py
+++ b/python/test/dynamo/importer_basic_test.py
@@ -65,68 +65,28 @@ class ImportTests(unittest.TestCase):
         opt_foo(torch.ones(10))
 
     def testImportDevice(self):
-        imp = FxImporter()
-
-        def import_compiler(gm: GraphModule, example_inputs):
-            gm.print_readable()
-            try:
-                imp.import_graph_module(gm)
-            finally:
-                print(imp.module)
-            imp.module.operation.verify()
-            return gm
-
-        backend = import_compiler
-        backend = aot_autograd(fw_compiler=backend)
-
         def foo(x):
             return torch.arange(x, device="cpu")
 
-        opt_foo = torch.compile(foo, backend=backend)
+        opt_foo = torch.compile(foo, backend=self.create_backend())
         opt_foo(10)
 
     def testImportLayout(self):
-        imp = FxImporter()
-        def import_compiler(gm: GraphModule, example_inputs):
-            gm.print_readable()
-            try:
-                imp.import_graph_module(gm)
-            finally:
-                print(imp.module)
-            imp.module.operation.verify()
-            return gm
-
-        backend = import_compiler
-        backend = aot_autograd(fw_compiler=backend)
-
         def foo(x):
             # sparse layouts are not currently supported as they can not be created on the 'meta' device
             return torch.ones_like(x, layout=torch.strided)
 
-        opt_foo = torch.compile(foo, backend=backend)
+        opt_foo = torch.compile(foo, backend=self.create_backend())
         opt_foo(torch.randn(10))
 
     def testImportMemoryFormat(self):
-        imp = FxImporter()
-        def import_compiler(gm: GraphModule, example_inputs):
-            gm.print_readable()
-            try:
-                imp.import_graph_module(gm)
-            finally:
-                print(imp.module)
-            imp.module.operation.verify()
-            return gm
-
-        backend = import_compiler
-        backend = aot_autograd(fw_compiler=backend)
-
         def foo():
             x = torch.ones_like(torch.randn(10), memory_format=torch.contiguous_format)
             x = torch.ones_like(torch.randn(10), memory_format=torch.preserve_format)
             x = torch.ones_like(torch.randn(1,1,1,1), memory_format=torch.channels_last)
             x = torch.ones_like(torch.randn(1,1,1,1,1), memory_format=torch.channels_last_3d)
 
-        opt_foo = torch.compile(foo, backend=backend)
+        opt_foo = torch.compile(foo, backend=self.create_backend())
         opt_foo()
 
 

--- a/python/test/dynamo/multiple_aten_results_test.py
+++ b/python/test/dynamo/multiple_aten_results_test.py
@@ -9,6 +9,7 @@ from torch.fx import (
     GraphModule,
 )
 
+
 class RandomTests(unittest.TestCase):
     def testInitialize(self):
         imp = FxImporter()
@@ -29,12 +30,11 @@ class RandomTests(unittest.TestCase):
         backend = import_compiler
         backend = aot_autograd(fw_compiler=backend)
 
-
         import torch.nn as nn
         import torch.nn.functional as F
 
         class Scaled_Dot_Product_Attention(nn.Module):
-            """Scaled Dot-Product Attention """
+            """Scaled Dot-Product Attention"""
 
             def __init__(self):
                 super(Scaled_Dot_Product_Attention, self).__init__()
@@ -56,9 +56,7 @@ class RandomTests(unittest.TestCase):
                 context = torch.matmul(attention, V)
                 return context
 
-
         class Multi_Head_Attention(nn.Module):
-
             def __init__(self, dim_model, num_head, dropout=0.0):
                 super(Multi_Head_Attention, self).__init__()
                 self.num_head = num_head

--- a/python/test/dynamo/tensor_test.py
+++ b/python/test/dynamo/tensor_test.py
@@ -79,6 +79,7 @@ class TensorTest(unittest.TestCase):
         t1 = torch.rand(4, device="turbine", dtype=torch.float32)
         print(t1.cpu())
 
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     unittest.main()


### PR DESCRIPTION
This PR addresses importing torch enum types (`torch.dtype`, `torch.layout`, `torch.memory_format`) by converting them to the proper integer values. 