### PR TITLE
Support for fx.Node operands in list arguments

### DIFF
--- a/python/test/dynamo/importer_basic_test.py
+++ b/python/test/dynamo/importer_basic_test.py
@@ -93,6 +93,20 @@ class ImportTests(unittest.TestCase):
         opt_foo = torch.compile(foo, backend=self.create_backend())
         opt_foo()
 
+    def testImportListArgs(self):
+        def foo():
+            return torch.randn((4,5,6))
+
+        opt_foo = torch.compile(foo, backend=self.create_backend())
+        opt_foo()
+
+    def testImportListNodeArgs(self):
+        def foo(x,y):
+            return torch.cat((x,y), 0)
+
+        opt_foo = torch.compile(foo, backend=self.create_backend())
+        opt_foo(torch.randn(10), torch.randn(10))
+
     def testImportVisionModule(self):
         from torch import nn
         import torch.nn.functional as F


### PR DESCRIPTION
Adds support for a case when importing a list argument whose operands are fx.Nodes rather than scalar constants. We already handle a case like the following `torch.randn((3,3,10))`, here the first argument is a list, `size`, where each element is a scalar constant - however when the list elements are instead the result of other operations then they will be parsed by Dynamo as `fx.Node` types. For instance when we do something like

```
x, y = torch.randn(10), torch.randn(10)
z = torch.cat((x,y), 0)
```
each tensor is actually an `fx.Node` referencing an MlirValue, so we have to extract the corresponding MlirValue to construct the appropriate list value as an argument to the torch operation `cat`.