### PR TITLE
Accept default list arguments

### DIFF
--- a/python/shark_turbine/dynamo/importer.py
+++ b/python/shark_turbine/dynamo/importer.py
@@ -492,11 +492,12 @@ class GraphNodeImporter:
                     raise RuntimeError(f"Attempt to de-reference a multi-result node")
                 val = self._v[(operand,0)]
                 if result_type is None:
-                    list_type: str = str(val.type)
-                    begin_index = 7 if list_type.startswith("!torch.") else None
-                    end_index = list_type.find("<")
-                    end_index = end_index if end_index != -1 else None
-                    list_type = list_type[begin_index:end_index]
+                    # parse torch list type from MlirType string representation
+                    pattern = r"^!torch\.(.*?)(?:<.*>)?$"
+                    val_type = str(val.type)
+                    match = re.match(pattern, val_type)
+                    assert match is not None, f"Unexpected MlirType in list: \'{val_type}\'"
+                    list_type = match.group(1)
                     result_type = MlirType.parse(f"!torch.list<{list_type}>")
             else:
                 val = self._import_default_value(


### PR DESCRIPTION
This refactors the list construction logic into a new importer method `_import_list_argument`, cases where users explicitly pass lists were handled before in `_import_argument` but when the list arguments are instead filled by default value we have to use essentially the same logic to construct the list. 

For example:
```py
def foo():
    m = nn.MaxPool2d(2, 2, 1) # params like 'dilation' are defaulted to a constant list: [1,1]
    return m(torch.randn(1,256,256))
```

I implemented this as a class method because the logic for most other cases requires access to the importer's state, and creating a separate method to call from `LITERAL_CONVERTER_MAP` to handle the case with lists made purely of constant values would repeat code (and require breaking the signature convention we are using for this lookup table), but I can edit this as needed. 

I also didn't include a test case here because this really reuses existing logic, but if we think it's needed I can include one.