### PR TITLE
xfail `chunk`, `tolist`, and `list`

### DIFF
--- a/python/shark_turbine/dynamo/importer.py
+++ b/python/shark_turbine/dynamo/importer.py
@@ -135,10 +135,10 @@ class FxImporter:
     ]
 
     def __init__(
-        self,
-        module: Optional[Module] = None,
-        context: Optional[Context] = None,
-        config_check: bool = True,
+            self,
+            module: Optional[Module] = None,
+            context: Optional[Context] = None,
+            config_check: bool = True,
     ):
         if module is not None:
             assert context is None, "If configuring with a Module, context must be None"
@@ -379,7 +379,7 @@ class GraphNodeImporter:
                     func_dialect.ReturnOp(operands, loc=loc)
 
     def _import_torch_op_overload(
-        self, loc: Location, node: torch_fx.Node, target: TorchOpOverload
+            self, loc: Location, node: torch_fx.Node, target: TorchOpOverload
     ):
         schema = target._schema
         assert isinstance(schema, FunctionSchema)
@@ -393,7 +393,7 @@ class GraphNodeImporter:
 
         # Intervening to use Scalar ops due to incorrect ops from AOT-autograd with scalar arguments.
         if mlir_op_name in TENSOR_SCALAR_OP_CONVERTER and (
-            isinstance(node.args[1], float) or isinstance(node.args[1], int)
+                isinstance(node.args[1], float) or isinstance(node.args[1], int)
         ):
             mlir_op_name = TENSOR_SCALAR_OP_CONVERTER[mlir_op_name]
 
@@ -440,7 +440,7 @@ class GraphNodeImporter:
                         loc, parameter.default_value, parameter.type
                     )
                 )
-        print("result types: ", result_types)
+
         operation = Operation.create(
             mlir_op_name,
             results=result_types,
@@ -487,6 +487,21 @@ class GraphNodeImporter:
                     f"Lists with multiple types are not supported, got: {arg_type}, {operand_type}"
                 )
 
+                if isinstance(operand, torch.fx.Node):
+                    if operand in self._multi_result_nodes:
+                        raise RuntimeError(f"Attempt to de-reference a multi-result node")
+                    val = self._v[(operand, 0)]
+                    if result_type is None:
+                        list_type: str = str(val.type)
+                        begin_index = 7 if list_type.startswith("!torch.") else None
+                        end_index = list_type.find("<")
+                        end_index = end_index if end_index != -1 else None
+                        list_type = list_type[begin_index:end_index]
+                        result_type = MlirType.parse(f"!torch.list<{list_type}>")
+                else:
+                    val = self._import_default_value(
+                        loc, operand, SCALAR_TYPE_TO_TORCH_TYPE[type(operand)]
+                    )
             if isinstance(operand, torch.fx.Node):
                 if operand in self._multi_result_nodes:
                     raise RuntimeError(f"Attempt to de-reference a multi-result node")
@@ -569,7 +584,7 @@ class TypeSubclassMap:
 
 
 def _make_constant_op(
-    op_name: str, value_attr: MlirAttribute, result_type: Optional[MlirType] = None
+        op_name: str, value_attr: MlirAttribute, result_type: Optional[MlirType] = None
 ) -> Operation:
     return Operation.create(
         op_name,

--- a/python/shark_turbine/dynamo/importer.py
+++ b/python/shark_turbine/dynamo/importer.py
@@ -408,7 +408,8 @@ class GraphNodeImporter:
         return_count = len(schema.returns)
         if return_count == 1:
             # Unary return directly maps a single meta["val"] and cannot be subscripted.
-            result_types = [self._cc.tensor_metadata_to_type(node.meta["tensor_meta"])]
+            # if "tensor_meta" is None, this will throw unsupported placeholder node error
+            result_types = [self._cc.node_val_to_type(node)]
         elif return_count == 0:
             # TODO: Implement.
             raise NotImplementedError("FIXME: Zero ATen results")
@@ -424,7 +425,6 @@ class GraphNodeImporter:
             result_types = tuple(result_types)
 
             self._multi_result_nodes.add(node)
-
         # Unroll operands from formal parameters, args and kwargs.
         operands = []
         for i, parameter in enumerate(schema.arguments):
@@ -440,7 +440,7 @@ class GraphNodeImporter:
                         loc, parameter.default_value, parameter.type
                     )
                 )
-
+        print("result types: ", result_types)
         operation = Operation.create(
             mlir_op_name,
             results=result_types,

--- a/python/test/dynamo/importer_basic_test.py
+++ b/python/test/dynamo/importer_basic_test.py
@@ -107,6 +107,27 @@ class ImportTests(unittest.TestCase):
         opt_foo = torch.compile(foo, backend=self.create_backend())
         opt_foo(torch.randn(10), torch.randn(10))
 
+    @unittest.expectedFailure
+    def testImportListOfTensor(self):
+        def foo():
+            z = (torch.randn([1, 2]), torch.randn([3, 4]))
+            return list(z)
+
+        opt = torch.compile(foo, backend=self.create_backend())
+        opt()
+        print(foo())
+
+    @unittest.expectedFailure
+    def testImportChunk(self):
+        def foo(x):
+            return torch.chunk(x, 2, dim=-1)
+
+        opt = torch.compile(foo, backend=self.create_backend())
+        opt(torch.randn([4, 4, 4, 4]))
+        print(foo(torch.randn([4, 4, 4, 4])))
+
+
+
     def testImportVisionModule(self):
         from torch import nn
         import torch.nn.functional as F

--- a/python/test/dynamo/importer_basic_test.py
+++ b/python/test/dynamo/importer_basic_test.py
@@ -111,7 +111,7 @@ class ImportTests(unittest.TestCase):
     def testImportChunk(self):
         """
         Annotated to be an expected failure due to Unsupported placeholder node, where FX graph
-        does not return meta_data["tensor_meta"] to create Ops. Also, same problem with split.Tensor and unbind.int.
+        does not return meta_data["tensor_meta"] to create Ops. Same problem occurs with split.Tensor and unbind.int.
         Needs to identify the root cause.
         """
 

--- a/python/test/dynamo/importer_basic_test.py
+++ b/python/test/dynamo/importer_basic_test.py
@@ -95,38 +95,32 @@ class ImportTests(unittest.TestCase):
 
     def testImportListArgs(self):
         def foo():
-            return torch.randn((4,5,6))
+            return torch.randn((4, 5, 6))
 
         opt_foo = torch.compile(foo, backend=self.create_backend())
         opt_foo()
 
     def testImportListNodeArgs(self):
-        def foo(x,y):
-            return torch.cat((x,y), 0)
+        def foo(x, y):
+            return torch.cat((x, y), 0)
 
         opt_foo = torch.compile(foo, backend=self.create_backend())
         opt_foo(torch.randn(10), torch.randn(10))
 
     @unittest.expectedFailure
-    def testImportListOfTensor(self):
-        def foo():
-            z = (torch.randn([1, 2]), torch.randn([3, 4]))
-            return list(z)
-
-        opt = torch.compile(foo, backend=self.create_backend())
-        opt()
-        print(foo())
-
-    @unittest.expectedFailure
     def testImportChunk(self):
-        def foo(x):
+        """
+        Annotated to be an expected failure due to Unsupported placeholder node, where FX graph
+        does not return meta_data["tensor_meta"] to create Ops. Also, same problem with split.Tensor and unbind.int.
+        Needs to identify the root cause.
+        """
+
+        def foo_chunk(x):
             return torch.chunk(x, 2, dim=-1)
 
-        opt = torch.compile(foo, backend=self.create_backend())
-        opt(torch.randn([4, 4, 4, 4]))
-        print(foo(torch.randn([4, 4, 4, 4])))
-
-
+        opt = torch.compile(foo_chunk, backend=self.create_backend())
+        t = torch.randn([4, 4, 4, 4])
+        opt(t)
 
     def testImportVisionModule(self):
         from torch import nn

--- a/python/test/dynamo/multiple_aten_results_test.py
+++ b/python/test/dynamo/multiple_aten_results_test.py
@@ -34,21 +34,11 @@ class RandomTests(unittest.TestCase):
         import torch.nn.functional as F
 
         class Scaled_Dot_Product_Attention(nn.Module):
-            """Scaled Dot-Product Attention"""
 
             def __init__(self):
                 super(Scaled_Dot_Product_Attention, self).__init__()
 
             def forward(self, Q, K, V, scale=None):
-                """
-                Args:
-                    Q: [batch_size, len_Q, dim_Q]
-                    K: [batch_size, len_K, dim_K]
-                    V: [batch_size, len_V, dim_V]
-                    scale: 缩放因子 论文为根号dim_K
-                Return:
-                    self-attention后的张量，以及attention张量
-                """
                 attention = torch.matmul(Q, K.permute(0, 2, 1))
                 if scale:
                     attention = attention * scale


### PR DESCRIPTION
Marked expected failure for the following test cases: 
1. `aten.chunk` 
- FX node does not have meta_data["tensor_meta"], and fails to emit `result_types` of list of tensors, required for op creation
- Commented `aten.split.Tensor` `aten.unbind.int`would also fail for similar reason in the test case
- Further investigation on torch-mlir, FX graph, Dynamo needed.

2. `tolist` and standard python `list()` 
- `No stacktrace found for following nodes: _tensor_constant0 = self._tensor_constant0` results in lacking `operands` and failure in attaching to op creation, where `aten.lift_fresh_copy` op is invovled