### PR TITLE
Test simple backward

### DIFF
--- a/python/shark_turbine/dynamo/importer.py
+++ b/python/shark_turbine/dynamo/importer.py
@@ -351,8 +351,6 @@ class GraphNodeImporter:
                     self._v[(node, 0)] = self._b.arguments[num_placeholders]
                     num_placeholders += 1
                 elif op == "call_function":
-                    # print("NODE", node
-                    # print("NODEMETA", node.meta)
 
                     target = node.target
                     if target == operator.getitem:

--- a/python/shark_turbine/dynamo/importer.py
+++ b/python/shark_turbine/dynamo/importer.py
@@ -153,7 +153,7 @@ class FxImporter:
             self._config_check()
         self._cc = ContextCache(self._c)
         self._m_ip = InsertionPoint(self._m.body)
-        self.used_function_names = set()
+        self.used_function_names: Set[str] = set()
 
     def _config_check(self):
         for dname in REQUIRED_DIALCTS:
@@ -173,6 +173,7 @@ class FxImporter:
         self.import_stateless_graph(gm.graph)
 
     def import_stateless_graph(self, g: Graph, func_name: str = "main"):
+        # TODO(Stella): Switch this to SymbolTable insertion/dedup
         if func_name in self.used_function_names:
             new_name = f"{func_name}_{len(self.used_function_names)}"
             func_name = new_name
@@ -351,7 +352,6 @@ class GraphNodeImporter:
                     self._v[(node, 0)] = self._b.arguments[num_placeholders]
                     num_placeholders += 1
                 elif op == "call_function":
-
                     target = node.target
                     if target == operator.getitem:
                         # Special case handling of getitem for when it is resolving

--- a/python/shark_turbine/dynamo/importer.py
+++ b/python/shark_turbine/dynamo/importer.py
@@ -132,6 +132,7 @@ class FxImporter:
         "_cc",
         "_m",
         "_m_ip",
+        "used_function_names",
     ]
 
     def __init__(
@@ -152,6 +153,7 @@ class FxImporter:
             self._config_check()
         self._cc = ContextCache(self._c)
         self._m_ip = InsertionPoint(self._m.body)
+        self.used_function_names = set()
 
     def _config_check(self):
         for dname in REQUIRED_DIALCTS:
@@ -171,6 +173,11 @@ class FxImporter:
         self.import_stateless_graph(gm.graph)
 
     def import_stateless_graph(self, g: Graph, func_name: str = "main"):
+        if func_name in self.used_function_names:
+            new_name = f"{func_name}_{len(self.used_function_names)}"
+            func_name = new_name
+        self.used_function_names.add(func_name)
+
         ftype, loc = self._graph_to_function_meta(g)
         # TODO: The FuncOp constructor requires a context-manager context.
         # Fix upstream and then unnest.
@@ -205,7 +212,10 @@ class FxImporter:
                 # An output node's args[0] is the return value. This seems to
                 # always be "boxed" as a tuple, which we emit as multi-results.
                 for result_node in node.args[0]:
-                    result_types.append(self._cc.node_val_to_type(result_node))
+                    if result_node is None:
+                        result_types.append(MlirType.parse("!torch.none", context=self._c))
+                    else:
+                        result_types.append(self._cc.node_val_to_type(result_node))
         return (
             FunctionType.get(input_types, result_types, context=self._c),
             loc if loc else Location.unknown(self._c),
@@ -341,6 +351,9 @@ class GraphNodeImporter:
                     self._v[(node, 0)] = self._b.arguments[num_placeholders]
                     num_placeholders += 1
                 elif op == "call_function":
+                    # print("NODE", node
+                    # print("NODEMETA", node.meta)
+
                     target = node.target
                     if target == operator.getitem:
                         # Special case handling of getitem for when it is resolving
@@ -505,7 +518,7 @@ class GraphNodeImporter:
             if isinstance(operand, torch.fx.Node):
                 if operand in self._multi_result_nodes:
                     raise RuntimeError(f"Attempt to de-reference a multi-result node")
-                val = self._v[(operand,0)]
+                val = self._v[(operand, 0)]
                 if result_type is None:
                     # parse torch list type from MlirType string representation
                     pattern = r"^!torch\.(.*?)(?:<.*>)?$"
@@ -653,12 +666,14 @@ SCALAR_TYPE_TO_TORCH_LIST_TYPE = {
     int: "!torch.list<int>",
     float: "!torch.list<float>",
     str: "!torch.list<str>",
+    bool: "!torch.list<bool>"
 }
 
 SCALAR_TYPE_TO_TORCH_TYPE = {
     int: "!torch.int",
     float: "!torch.float",
     str: "!torch.str",
+    bool: "!torch.bool"
 }
 
 # AOT-autograd sometimes falsely emit tensor version op with scalar arguments.

--- a/python/test/dynamo/importer_backward_test.py
+++ b/python/test/dynamo/importer_backward_test.py
@@ -45,6 +45,10 @@ class ImportTests(unittest.TestCase):
         opt_foo = torch.compile(foo, backend=self.create_backend())
         opt_foo(torch.randn(10), torch.randn(10, requires_grad=True))
 
+    # TODO: using func.grad for backward test
+
+    # TODO: MNIST Classifier using LeNet for backward test
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)

--- a/python/test/dynamo/importer_backward_test.py
+++ b/python/test/dynamo/importer_backward_test.py
@@ -1,0 +1,51 @@
+# Copyright 2023 Nod Labs, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+import struct
+import unittest
+
+from shark_turbine.dynamo.importer import FxImporter
+import torch
+import torch._dynamo as dynamo
+from torch._dynamo.backends.common import aot_autograd
+from torch.fx import (
+    GraphModule,
+)
+from torch.func import grad
+
+
+class ImportTests(unittest.TestCase):
+    def create_backend(self):
+        imp = FxImporter()
+
+        def import_compiler(gm: GraphModule, example_inputs):
+            gm.print_readable()
+            try:
+                imp.import_graph_module(gm)
+            finally:
+                print(imp.module)
+            imp.module.operation.verify()
+
+            return gm
+
+        backend = import_compiler
+        backend = aot_autograd(fw_compiler=backend)
+        return backend
+
+    def testImportCustomLossModule(self):
+        def foo(x, y):
+            loss = ((0.5 * x - y) ** 2).mean()
+            loss.backward()
+            return loss
+
+        opt_foo = torch.compile(foo, backend=self.create_backend())
+        opt_foo(torch.randn(10), torch.randn(10, requires_grad=True))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()


### PR DESCRIPTION
We implemented the followings for this PR:
- Added `importer_backward_test.py', which currently has a simple custom loss function for backward. 
Needs to add test cases including 1) using `func.grad` for backward test, and 2) MNIST Classifier using LeNet for backward test
- Parsing `!torch.none` to store MlirType of none for `result_types` to create required op
- Added `bool` for list construction. 

Test cases mentioned above will be added in the next PR.