### PR TITLE
Add a larger test suite

### DIFF
--- a/python/test/generated/main.py
+++ b/python/test/generated/main.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import argparse
+
+from testutils import evaluate_all
+
+# magic: makes importing this module work in the testsuite
+import torch._inductor.config
+
+import logging
+log = logging.getLogger("turbine-test")
+logging.basicConfig(level=logging.INFO)
+
+ENV_FILE = "JITPARITYBENCH_PATH.txt"
+
+def get_args(raw_args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--jobs", "-j", type=int, default=4, help="Number of threads in our threadpool, jobs=1 is essentially sequential execution")
+    parser.add_argument("--offset", type=int, default=0, help="Pick files starting from this offset. Together with --limit, we can run through all files in multiple separate runs")
+    parser.add_argument("--limit", "-l", type=int, help="only run the first N files")
+    parser.add_argument("--filter", "-f", "-k", help="only run module containing given name")
+    parser.add_argument("--skips", type=str)
+    parser.add_argument("--tests-dir", default=None, help="jit-paritybench location (i.e. /path/to/pytorch-jit-paritybench)")
+    # parser.add_argument("--device", default="cuda", type=str, help="evaluate modules using cuda or cpu") # excluded for now as we only have turbine-cpu, can use this later
+
+    args = parser.parse_args(raw_args)
+    return args
+
+def write_path(path: str):
+    with open(ENV_FILE, "w") as f:
+        f.write(path)
+
+def read_path() -> str:
+    with open(ENV_FILE, "r") as f:
+        path = f.read()
+    return path
+
+if __name__ == "__main__":
+    args = get_args()
+
+    if args.tests_dir is not None:
+        pb = args.tests_dir
+        write_path(pb) # store this path for next time
+        log.info(f"Using test directory from CLI: {pb}")
+    elif os.path.exists(ENV_FILE):
+        pb = read_path()
+        log.info(f"Using test directory from {ENV_FILE}: {pb}")
+    else:
+        raise RuntimeError(f"Must either pass 'tests-dir' or set {ENV_FILE} in order to run tests")
+
+    # enables finding necessary modules in jit-paritybench
+    pb_gen = pb + "/generated"
+    sys.path.append(pb)
+    sys.path.append(pb_gen)
+
+    evaluate_all(args, pb_gen, offset=args.offset, limit=args.limit, jobs=args.jobs)

--- a/python/test/generated/running_tests.md
+++ b/python/test/generated/running_tests.md
@@ -1,0 +1,44 @@
+# Running Tests
+
+## Set Up
+This test suite requires a local clone of the `pytorch-jit-paritybench` repository:
+```shell
+# somewhere ...
+git clone https://github.com/jansel/pytorch-jit-paritybench.git
+cd pytorch-jit-paritybench
+pip install -r requirements.txt
+conda install cpuonly -c pytorch-nightly
+```
+
+Note that we are not exactly following the setup described in the above repo, mainly to avoid issues with dependencies between `conda` and `pip` versions of relevant packages (see 'Known Issues' below).
+
+There may be some additional packages to install that are not in the requirements.txt in order to successfully run the tests, one that comes to mind is `expecttest`
+
+## Running
+Once everything is set up in your conda environment we can run the test suite using `python/test/generated/main.py`. Initially you have to pass the location of your `pytorch-jit-paritybench` repo to the script: `python main.py --tests-dir /path/to/pytorch-jit-paritybench`. After the first run, the script will save the path for future use in a local text file for convenience and you do not need to pass it again.
+
+To speed up iteration on tests it's recommended to make use of the `offset`, `limit`, and `filter` arguments as running the full test suite can take some time.
+
+## Help
+```
+usage: main.py [-h] [--jobs JOBS] [--offset OFFSET] [--limit LIMIT] [--filter FILTER] [--skips SKIPS] [--tests-dir TESTS_DIR]
+
+options:
+  -h, --help            show this help message and exit
+  --jobs JOBS, -j JOBS  Number of threads in our threadpool, jobs=1 is essentially sequential execution
+  --offset OFFSET       Pick files starting from this offset. Together with --limit, we can run through all files in multiple separate runs
+  --limit LIMIT, -l LIMIT
+                        only run the first N files
+  --filter FILTER, -f FILTER, -k FILTER
+                        only run module containing given name
+  --skips SKIPS
+  --tests-dir TESTS_DIR
+                        jit-paritybench location (i.e. /path/to/pytorch-jit-paritybench)
+
+```
+
+
+# Known Issues
+On Mac, setting resource limits via a python shell is finicky/not allowed this can cause issues with the jit parity-bench tests as they utilize the `resource` package to set an optional resource limit [here](https://github.com/jansel/pytorch-jit-paritybench/blob/7e55a422588c1d1e00f35a3d3a3ff896cce59e18/paritybench/utils.py#L57) - the simplest fix is to simply comment those lines out in your local `jit-paritybench` repo.
+
+Getting unknown symbol errors associated with a shared library (commonly a torch library) often occurs because of mixing conda installed dependencies with pip installed dependencies because of possible differences in how certain shared libraries are linked, if possible use pip for all of your dependencies (especially when they have a dependence on one another like torch, torchvision, and torchaudio)

--- a/python/test/generated/stats.py
+++ b/python/test/generated/stats.py
@@ -1,0 +1,86 @@
+import csv
+import logging
+import os
+import random
+import re
+from collections import Counter, defaultdict
+from typing import List
+
+log = logging.getLogger("turbine-test")
+
+
+class Stats(Counter):
+    """
+    Collect and group error messages for a debug report at the end
+    """
+
+    def __str__(self):
+        stats_keys = [
+            "PASSED",
+            "FAILED",
+            "SKIPPED",
+            "XFAILED",
+            "NO_FWD",
+            "TIMEOUT",
+            "CRASHED",
+            "TOTAL",
+        ]
+
+        return str([(k, self[k]) for k in stats_keys if k in self])
+
+class ErrorAggregatorDict(object):
+    """
+    Collect and group error messages for a debug report at the end
+    """
+
+    def __init__(self):
+        super(ErrorAggregatorDict, self).__init__()
+        self.errors = defaultdict(list)
+
+    def __len__(self):
+        return len(self.errors)
+
+    def __getitem__(self, item: str):
+        return self.errors[item]
+
+    def __iadd__(self, other):
+        self.update(other)
+        return self
+
+    @classmethod
+    def single(cls, error, name):
+        obj = ErrorAggregatorDict()
+        obj.insert(error, name)
+        return obj
+
+    def items(self):
+        return self.errors
+
+    # insert into dict with error string and test name
+    def insert(self, error: str, name: str):
+        self.errors[error].append(name)
+
+    def update(self, other):
+        if not len(other):
+            return
+
+        other_dict = other.items().items()
+        for error, names in other_dict:
+            self.errors[error] += names
+
+    def print_report(self):
+        if not len(self.errors):
+            log.info("No exceptions")
+            return
+
+        print("\n" + "".join("*" * 80) + "\n" + "EXCEPTIONS" + "\n" + "".join("*" * 80))
+        for error, test_names in sorted(self.errors.items(), key=lambda e: len(e[1])):
+            extra = ""
+            n_tests = len(test_names)
+            if n_tests > 15:
+                extra = ", ..."
+                test_names = test_names[:15]
+
+            print("\033[1;36m" + str(n_tests) + ": " + ", ".join(test_names) + extra + "\033[0;0m")
+            print("\033[1;31m" + error.strip() + "\033[0;0m" + "\n")
+            print("-"*20)

--- a/python/test/generated/testutils.py
+++ b/python/test/generated/testutils.py
@@ -1,0 +1,195 @@
+import time
+import types
+import os
+import re
+import sys
+from functools import partial
+import multiprocessing
+from multiprocessing.pool import ThreadPool
+import threading
+import signal
+import platform
+import resource
+import logging
+from tqdm import *
+
+from stats import Stats, ErrorAggregatorDict
+from evaluate import evaluate_importer
+
+log = logging.getLogger("turbine-test")
+
+
+def call_with_timeout(fn, args, kwargs=None, timeout=10):
+    kwargs = kwargs or {}
+    parent_conn, child_conn = multiprocessing.Pipe()
+    start = time.time()
+    proc = multiprocessing.Process(target=call_with_timeout_subproc, args=(fn, args, kwargs, child_conn))
+    proc.start()
+    while proc.is_alive():
+        if parent_conn.poll(1):
+            result = parent_conn.recv()
+            proc.join()
+            return result
+        if time.time() - start > timeout:
+            os.kill(proc.pid, signal.SIGINT)  # maybe generate a stack trace for debugging
+            time.sleep(1)
+            proc.terminate()
+            proc.join(10)
+            raise TimeoutError(f"took longer than {timeout} seconds")
+
+    proc.join()
+    if proc.exitcode == 0:
+        return parent_conn.recv()
+    else:
+        raise OSError(f"exitcode should be 0, got {proc.exitcode}")
+
+
+def call_with_timeout_subproc(fn, args, kwargs, return_pipe):
+    # use_rlimit = (
+    #     os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES") // 1024 ** 3 < 1000
+    #     if platform.system() == "Linux"
+    #     else True
+    # )
+    # if use_rlimit:
+    #     _, hard = resource.getrlimit(resource.RLIMIT_AS)
+    #     # resource.setrlimit(resource.RLIMIT_AS, (int(os.environ.get("RLIMIT_AS_GB", 10)) * 1024 ** 3, hard))
+    try:
+        result = fn(*args, *kwargs)
+        return_pipe.send(result)
+    except Exception:
+        log.exception("Error from subprocess")
+        sys.exit(1)
+
+def subproc_wrapper(path: str, fn: callable, timeout: int = 900):
+    """
+    A wrapper around call_with_timeout() adding a temp dir and error handling.
+
+    :param path: path to code to test
+    :param fn: function to run in subprocess
+    :param timeout: seconds to wait
+    :return: errors, stats
+    """
+    file = os.path.basename(path).split('/')[-1]
+    test_identifier = re.sub(r'\.py$', '', file)
+
+    log.info(f"Running {path}")
+    try:
+        return call_with_timeout(fn, [path], {}, timeout=timeout)
+    except TimeoutError as e:
+        return ErrorAggregatorDict.single(
+            str(e),
+            test_identifier
+        ), Stats({"TIMEOUT": 1})
+    except OSError as e:
+        return ErrorAggregatorDict.single(
+            str(e),
+            test_identifier
+        ), Stats({"CRASHED": 1})
+
+def import_file(path):
+    """
+    :param path: to a *.py file
+    :return: a python module
+    """
+    module = types.ModuleType(re.findall(r"test_[^.]+", path)[0])
+    sys.modules[module.__name__] = module
+    exec(compile(open(path).read(), filename=path, mode='exec'),
+         module.__dict__, module.__dict__)
+    if not hasattr(module, "TESTCASES"):
+        module.TESTCASES = []
+
+    return module
+
+
+def evaluate_pyfile_subproc(path: str, args, eval_fn=evaluate_importer):
+    """
+    Evaluate/test all the TESTCASES in path.
+
+    :param path: *.py file to test
+    :return: errors, stats
+    """
+    errors = ErrorAggregatorDict()
+    stats = Stats()
+    module = import_file(path)
+
+    if not module.TESTCASES:
+        log.info(f"Skipping empty module: {module.__name__}")
+        stats["SKIPPED"] += 1
+        return errors, stats
+
+    index = -1
+    for nn_cls, get_init_args, get_forward_args, compiles in module.TESTCASES:
+        index += 1
+        stats["TOTAL"] += 1
+
+        if args.filter and args.filter not in nn_cls.__name__:
+            stats["SKIPPED"] += 1
+            continue
+
+        if args.skips and f"{nn_cls.__name__}" in args.skips:
+            stats["SKIPPED"] += 1
+            continue
+
+        # nn.module doesn't have `forward` function(e.g, has __call__ instead).
+        # dynamo doesn't plan to support it yet.
+        if nn_cls.forward.__name__ == "_forward_unimplemented":
+            stats["NO_FWD"] += 1
+            continue
+
+        repro = f"{nn_cls.__name__} # pytest {path} -k test_{index:03d}"
+        test_identifier = f"{module.__name__}__{index:03d}"
+        eval_args = [nn_cls,
+                get_init_args,
+                get_forward_args,
+                test_identifier]
+
+        try:
+            err_dict = eval_fn(*eval_args)
+            if err_dict and len(err_dict):
+                log.info(f"{test_identifier} - FAIL")
+                errors.update(err_dict)
+                stats["FAILED"] += 1
+            else:
+                log.info(f"{test_identifier} - PASS")
+                stats["PASSED"] += 1
+        except Exception as e:
+            log.info(f"{test_identifier} - FAIL (Exception)")
+            errors.insert(str(e), test_identifier)
+
+    return errors, stats
+
+
+def evaluate_all(args, tests_dir: str = './generated', offset: int = 0, limit: int = None,
+                 jobs=4):
+    """
+    Generate a paritybench score, main entrypoint for this module.
+
+    :param tests_dir: directory containing paritybench testcases
+    :param limit: optional maximum number of files to process
+    :param fn: inner function to run the tests
+    :param jobs: how many processes to run at once
+    """
+    feval = partial(evaluate_pyfile_subproc, args=args)
+    fn = partial(subproc_wrapper, fn=feval)
+    start = time.time()
+    stats = Stats()
+    errors = ErrorAggregatorDict()
+    testfiles = [os.path.join(tests_dir, f)
+                 for f in os.listdir(tests_dir)
+                 if re.search(r"test_.*[.]py$", f)]
+    testfiles.sort()
+
+    if limit:
+        testfiles = testfiles[offset: offset+limit]
+
+    with tqdm(total=len(testfiles)) as pbar:
+        pool = ThreadPool(jobs)
+        for errors_part, stats_part in pool.imap_unordered(fn, testfiles):
+            errors.update(errors_part)
+            stats.update(stats_part)
+            pbar.update()
+        pool.close()
+
+    errors.print_report()
+    log.info(f"Total time: {time.time() - start:02f} s")
+    log.info(stats)


### PR DESCRIPTION
Courtesy of `pytorch-jit-paritybench` this adds the ability to run our Turbine importer on the full generated test suite from there and returns a sorted list of errors (by their prevalence in the test suite) for us to triage. Eventually, we can add other test functions for other aspects of Turbine or different device backends. 

How it works is largely explained in `running_tests.md`