### PR TITLE
Add decompositions to import flow

### DIFF
--- a/python/shark_turbine/dynamo/backends/cpu.py
+++ b/python/shark_turbine/dynamo/backends/cpu.py
@@ -37,6 +37,9 @@ from ..importer import FxImporter
 
 import torch
 from torch._dynamo.backends.common import aot_autograd
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch._decomp import get_decompositions
+from torch.func import functionalize
 
 DEFAULT_COMPILER_FLAGS = (
     # Enable asynchronous calling convention.
@@ -45,6 +48,23 @@ DEFAULT_COMPILER_FLAGS = (
     "--iree-input-type=tm_tensor",
 )
 
+def default_decompositions():
+    return get_decompositions(
+        [
+            torch.ops.aten.embedding_dense_backward,
+            torch.ops.aten.native_layer_norm_backward,
+            torch.ops.aten.slice_backward,
+            torch.ops.aten.select_backward,
+            torch.ops.aten.norm.ScalarOpt_dim,
+            torch.ops.aten.native_group_norm,
+            torch.ops.aten.upsample_bilinear2d.vec,
+            torch.ops.aten.split.Tensor,
+            torch.ops.aten.split_with_sizes,
+            torch.ops.aten.native_layer_norm,
+            torch.ops.aten.masked_fill.Tensor,
+            torch.ops.aten.masked_fill.Scalar,
+        ]
+    )
 
 def _base_backend(gm: torch.fx.GraphModule, example_inputs):
     # Set up the session, context and invocation.
@@ -64,6 +84,12 @@ def _base_backend(gm: torch.fx.GraphModule, example_inputs):
     # TODO: Should capture diagnostics.
     inv.enable_console_diagnostics()
     inv.import_module(module.operation)
+
+    # Apply decompositions.
+    gm = make_fx(
+        functionalize(gm),
+        decomposition_table=default_decompositions(),
+    )(*example_inputs)
 
     # Import phase.
     importer.import_graph_module(gm)

--- a/python/shark_turbine/dynamo/backends/cpu.py
+++ b/python/shark_turbine/dynamo/backends/cpu.py
@@ -46,6 +46,7 @@ DEFAULT_COMPILER_FLAGS = (
     "--iree-input-type=tm_tensor",
 )
 
+
 def _base_backend(gm: torch.fx.GraphModule, example_inputs):
     # Set up the session, context and invocation.
     # Note that we do this on one in-memory module in a few phases:

--- a/python/shark_turbine/dynamo/backends/cpu.py
+++ b/python/shark_turbine/dynamo/backends/cpu.py
@@ -63,6 +63,8 @@ def default_decompositions():
             torch.ops.aten.native_layer_norm,
             torch.ops.aten.masked_fill.Tensor,
             torch.ops.aten.masked_fill.Scalar,
+            torch.ops.aten._native_batch_norm_legit_functional,
+            torch.ops.aten.squeeze.dims,
         ]
     )
 

--- a/python/shark_turbine/dynamo/passes.py
+++ b/python/shark_turbine/dynamo/passes.py
@@ -6,18 +6,18 @@ from typing import List
 
 # default decompositions pulled from SHARK
 DEFAULT_DECOMPOSITIONS = [
-            torch.ops.aten.embedding_dense_backward,
-            torch.ops.aten.native_layer_norm_backward,
-            torch.ops.aten.slice_backward,
-            torch.ops.aten.select_backward,
-            torch.ops.aten.norm.ScalarOpt_dim,
-            torch.ops.aten.native_group_norm,
-            torch.ops.aten.upsample_bilinear2d.vec,
-            torch.ops.aten.split.Tensor,
-            torch.ops.aten.split_with_sizes,
-            torch.ops.aten.native_layer_norm,
-            torch.ops.aten.masked_fill.Tensor,
-            torch.ops.aten.masked_fill.Scalar,
+    torch.ops.aten.embedding_dense_backward,
+    torch.ops.aten.native_layer_norm_backward,
+    torch.ops.aten.slice_backward,
+    torch.ops.aten.select_backward,
+    torch.ops.aten.norm.ScalarOpt_dim,
+    torch.ops.aten.native_group_norm,
+    torch.ops.aten.upsample_bilinear2d.vec,
+    torch.ops.aten.split.Tensor,
+    torch.ops.aten.split_with_sizes,
+    torch.ops.aten.native_layer_norm,
+    torch.ops.aten.masked_fill.Tensor,
+    torch.ops.aten.masked_fill.Scalar,
 ]
 
 # decompositions that aid us in handling nn.BatchNorm2d
@@ -27,7 +27,11 @@ BATCHNORM_DECOMPOSITIONS = [
 ]
 
 
-def apply_decompositions(gm: torch.fx.GraphModule, example_inputs, decompose_ops: List[torch._ops.OpOverload] = None):
+def apply_decompositions(
+    gm: torch.fx.GraphModule,
+    example_inputs,
+    decompose_ops: List[torch._ops.OpOverload] = None,
+):
     if decompose_ops is None:
         return gm
 

--- a/python/shark_turbine/dynamo/passes.py
+++ b/python/shark_turbine/dynamo/passes.py
@@ -1,0 +1,45 @@
+import torch
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch._decomp import get_decompositions
+from torch.func import functionalize
+from typing import List
+
+# default decompositions pulled from SHARK
+DEFAULT_DECOMPOSITIONS = [
+            torch.ops.aten.embedding_dense_backward,
+            torch.ops.aten.native_layer_norm_backward,
+            torch.ops.aten.slice_backward,
+            torch.ops.aten.select_backward,
+            torch.ops.aten.norm.ScalarOpt_dim,
+            torch.ops.aten.native_group_norm,
+            torch.ops.aten.upsample_bilinear2d.vec,
+            torch.ops.aten.split.Tensor,
+            torch.ops.aten.split_with_sizes,
+            torch.ops.aten.native_layer_norm,
+            torch.ops.aten.masked_fill.Tensor,
+            torch.ops.aten.masked_fill.Scalar,
+]
+
+# decompositions that aid us in handling nn.BatchNorm2d
+BATCHNORM_DECOMPOSITIONS = [
+    torch.ops.aten._native_batch_norm_legit_functional,
+    torch.ops.aten.squeeze.dims,
+]
+
+
+def apply_decompositions(gm: torch.fx.GraphModule, example_inputs, decompose_ops: List[torch._ops.OpOverload] = None):
+    if decompose_ops is None:
+        return gm
+
+    decompositions = get_decompositions(decompose_ops)
+    gm = make_fx(
+        functionalize(gm),
+        decomposition_table=decompositions,
+    )(*example_inputs)
+
+    return gm
+
+
+def turbine_cpu_pass_pipeline(gm: torch.fx.GraphModule, example_inputs):
+    decompose_ops = DEFAULT_DECOMPOSITIONS + BATCHNORM_DECOMPOSITIONS
+    return apply_decompositions(gm, example_inputs, decompose_ops)

--- a/python/test/dynamo/importer_basic_test.py
+++ b/python/test/dynamo/importer_basic_test.py
@@ -125,6 +125,14 @@ class ImportTests(unittest.TestCase):
         t = torch.randn([4, 4, 4, 4])
         opt(t)
 
+    def testImportDecomposeBatchNorm2D(self):
+        def foo_chunk(x):
+            return torch.nn.BatchNorm2d(4)(x)
+
+        opt = torch.compile(foo_chunk, backend=self.create_backend(decompose_ops=[torch.ops.aten._native_batch_norm_legit_functional, torch.ops.aten.squeeze.dims,]))
+        t = torch.randn([4, 4, 4, 4])
+        opt(t)
+
     @unittest.expectedFailure
     def testImportToList(self):
         """

--- a/python/test/dynamo/importer_basic_test.py
+++ b/python/test/dynamo/importer_basic_test.py
@@ -121,7 +121,15 @@ class ImportTests(unittest.TestCase):
         def foo_chunk(x):
             return torch.chunk(x, 2, dim=-1)
 
-        opt = torch.compile(foo_chunk, backend=self.create_backend(decompose_ops=[torch.ops.aten.split.Tensor, torch.ops.aten.split_with_sizes,]))
+        opt = torch.compile(
+            foo_chunk,
+            backend=self.create_backend(
+                decompose_ops=[
+                    torch.ops.aten.split.Tensor,
+                    torch.ops.aten.split_with_sizes,
+                ]
+            ),
+        )
         t = torch.randn([4, 4, 4, 4])
         opt(t)
 
@@ -129,7 +137,15 @@ class ImportTests(unittest.TestCase):
         def foo_chunk(x):
             return torch.nn.BatchNorm2d(4)(x)
 
-        opt = torch.compile(foo_chunk, backend=self.create_backend(decompose_ops=[torch.ops.aten._native_batch_norm_legit_functional, torch.ops.aten.squeeze.dims,]))
+        opt = torch.compile(
+            foo_chunk,
+            backend=self.create_backend(
+                decompose_ops=[
+                    torch.ops.aten._native_batch_norm_legit_functional,
+                    torch.ops.aten.squeeze.dims,
+                ]
+            ),
+        )
         t = torch.randn([4, 4, 4, 4])
         opt(t)
 

--- a/python/test/dynamo/multiple_aten_results_test.py
+++ b/python/test/dynamo/multiple_aten_results_test.py
@@ -34,7 +34,6 @@ class RandomTests(unittest.TestCase):
         import torch.nn.functional as F
 
         class Scaled_Dot_Product_Attention(nn.Module):
-
             def __init__(self):
                 super(Scaled_Dot_Product_Attention, self).__init__()
 

--- a/python/test/generated/evaluate.py
+++ b/python/test/generated/evaluate.py
@@ -9,22 +9,51 @@ from torch.fx import (
     GraphModule,
 )
 
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch._decomp import get_decompositions
+from torch.func import functionalize
+from typing import List
+
+def default_decompositions():
+    return get_decompositions(
+        [
+            torch.ops.aten.embedding_dense_backward,
+            torch.ops.aten.native_layer_norm_backward,
+            torch.ops.aten.slice_backward,
+            torch.ops.aten.select_backward,
+            torch.ops.aten.norm.ScalarOpt_dim,
+            torch.ops.aten.native_group_norm,
+            torch.ops.aten.upsample_bilinear2d.vec,
+            torch.ops.aten.split.Tensor,
+            torch.ops.aten.split_with_sizes,
+            torch.ops.aten.native_layer_norm,
+            torch.ops.aten.masked_fill.Tensor,
+            torch.ops.aten.masked_fill.Scalar,
+        ]
+    )
+
+
 def create_backend():
     imp = FxImporter()
 
     def import_compiler(gm: GraphModule, example_inputs):
-        # gm.print_readable()
+        gm = make_fx(
+            functionalize(gm),
+            decomposition_table=default_decompositions(),
+        )(*example_inputs)
+
+        gm.print_readable()
         try:
             imp.import_graph_module(gm)
         finally:
-            pass
-            # print(imp.module)
+            print(imp.module)
         imp.module.operation.verify()
         return gm
 
     backend = import_compiler
     backend = aot_autograd(fw_compiler=backend)
     return backend
+
 
 def evaluate_importer(nn_cls, get_init_args, get_forward_args, test_identifier):
     log = logging.getLogger("turbine-test")

--- a/python/test/generated/evaluate.py
+++ b/python/test/generated/evaluate.py
@@ -29,6 +29,8 @@ def default_decompositions():
             torch.ops.aten.native_layer_norm,
             torch.ops.aten.masked_fill.Tensor,
             torch.ops.aten.masked_fill.Scalar,
+            torch.ops.aten._native_batch_norm_legit_functional,
+            torch.ops.aten.squeeze.dims,
         ]
     )
 
@@ -42,11 +44,10 @@ def create_backend():
             decomposition_table=default_decompositions(),
         )(*example_inputs)
 
-        gm.print_readable()
         try:
             imp.import_graph_module(gm)
         finally:
-            print(imp.module)
+            pass
         imp.module.operation.verify()
         return gm
 

--- a/python/test/generated/evaluate.py
+++ b/python/test/generated/evaluate.py
@@ -14,6 +14,7 @@ from torch._decomp import get_decompositions
 from torch.func import functionalize
 from typing import List
 
+
 def default_decompositions():
     return get_decompositions(
         [

--- a/python/test/generated/main.py
+++ b/python/test/generated/main.py
@@ -8,45 +8,69 @@ from testutils import evaluate_all
 import torch._inductor.config
 
 import logging
+
 log = logging.getLogger("turbine-test")
 logging.basicConfig(level=logging.INFO)
 
 ENV_FILE = "JITPARITYBENCH_PATH.txt"
 
+
 def get_args(raw_args=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument("--jobs", "-j", type=int, default=4, help="Number of threads in our threadpool, jobs=1 is essentially sequential execution")
-    parser.add_argument("--offset", type=int, default=0, help="Pick files starting from this offset. Together with --limit, we can run through all files in multiple separate runs")
+    parser.add_argument(
+        "--jobs",
+        "-j",
+        type=int,
+        default=4,
+        help="Number of threads in our threadpool, jobs=1 is essentially sequential execution",
+    )
+    parser.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Pick files starting from this offset. Together with --limit, we can run through all files in multiple separate runs",
+    )
     parser.add_argument("--limit", "-l", type=int, help="only run the first N files")
-    parser.add_argument("--filter", "-f", "-k", help="only run module containing given name")
+    parser.add_argument(
+        "--filter", "-f", "-k", help="only run module containing given name"
+    )
     parser.add_argument("--skips", type=str)
-    parser.add_argument("--tests-dir", default=None, help="jit-paritybench location (i.e. /path/to/pytorch-jit-paritybench)")
+    parser.add_argument(
+        "--tests-dir",
+        default=None,
+        help="jit-paritybench location (i.e. /path/to/pytorch-jit-paritybench)",
+    )
     # parser.add_argument("--device", default="cuda", type=str, help="evaluate modules using cuda or cpu") # excluded for now as we only have turbine-cpu, can use this later
 
     args = parser.parse_args(raw_args)
     return args
 
+
 def write_path(path: str):
     with open(ENV_FILE, "w") as f:
         f.write(path)
+
 
 def read_path() -> str:
     with open(ENV_FILE, "r") as f:
         path = f.read()
     return path
 
+
 if __name__ == "__main__":
     args = get_args()
 
     if args.tests_dir is not None:
         pb = args.tests_dir
-        write_path(pb) # store this path for next time
+        write_path(pb)  # store this path for next time
         log.info(f"Using test directory from CLI: {pb}")
     elif os.path.exists(ENV_FILE):
         pb = read_path()
         log.info(f"Using test directory from {ENV_FILE}: {pb}")
     else:
-        raise RuntimeError(f"Must either pass 'tests-dir' or set {ENV_FILE} in order to run tests")
+        raise RuntimeError(
+            f"Must either pass 'tests-dir' or set {ENV_FILE} in order to run tests"
+        )
 
     # enables finding necessary modules in jit-paritybench
     pb_gen = pb + "/generated"

--- a/python/test/generated/stats.py
+++ b/python/test/generated/stats.py
@@ -28,6 +28,7 @@ class Stats(Counter):
 
         return str([(k, self[k]) for k in stats_keys if k in self])
 
+
 class ErrorAggregatorDict(object):
     """
     Collect and group error messages for a debug report at the end
@@ -81,6 +82,13 @@ class ErrorAggregatorDict(object):
                 extra = ", ..."
                 test_names = test_names[:15]
 
-            print("\033[1;36m" + str(n_tests) + ": " + ", ".join(test_names) + extra + "\033[0;0m")
+            print(
+                "\033[1;36m"
+                + str(n_tests)
+                + ": "
+                + ", ".join(test_names)
+                + extra
+                + "\033[0;0m"
+            )
             print("\033[1;31m" + error.strip() + "\033[0;0m" + "\n")
-            print("-"*20)
+            print("-" * 20)


### PR DESCRIPTION
Adds default decompositions from SHARK to the Turbine import flow, with a test for importing `aten.chunk` which previously failed.

A few design questions:
1) Here I've included all the default decompositions present in SHARK, do we want to keep it this way or should I by default include a more minimal set?

2) I've hardcoded the above set of default decompositions for our CPU backend, but we spoke about making decompositions configurable - do we want a nice, user-facing way to do this or only want this for development purposes? I'm trying to figure out the best way to include this feature without it seeming awkward


Also, adding default decompositions to the generated tests passes an extra 50 cases when considering the first 700 or so test cases (this equates to setting `--limit 100` when running the test suite)