### PR TITLE
Handle lists of optional arguments

### DIFF
--- a/python/shark_turbine/known_issues.md
+++ b/python/shark_turbine/known_issues.md
@@ -1,6 +1,5 @@
 # Known Issues in SHARK-Turbine
 
-
 ## Dealing with functional variants of Torch Ops
 
 ```py


### PR DESCRIPTION
This addresses the most common issue in our [known issues doc](https://github.com/nod-ai/SHARK-Turbine/blob/8fcbac138777812f7b244a3182dacbaafb0d046e/python/shark_turbine/known_issues.md), handling optional arguments by using typing metadata present in the `FunctionSchema` for `OpOverload` nodes. It adds a test case (in addition to existing cases handling list arguments) and also removes that issue from the `known_issues.md` document.

This allows us to eliminate the hacky string manipulation and regex logic from the previous implementation.