### PR TITLE
Known issues v2

### DIFF
--- a/python/shark_turbine/known_issues.md
+++ b/python/shark_turbine/known_issues.md
@@ -58,9 +58,9 @@ nop_decomposition() decomposes `aten.detach`, `aten.lift`, `aten.lift_fresh` int
 
 This is because `aten.lift_fresh` and `aten.lift_fresh_copy` are functionalized here.
 There's no decomposition of functionalized `aten.lift_fresh` and `aten.lift_fresh_copy` currently.
-Which is why I think inductor is lowering it down to IR. (need to test)
+When using `inductor`, these ops are transformed to `aten.clone` and lowered down to IR.
 
-
+TODO: Figure out how `aten.lift_fresh` and `aten.lift_fresh_copy` works in `eager` mode.
 
 ```python
 def basic_3(x):
@@ -78,6 +78,4 @@ but throws an assertion ero saying that fake inputs should have constants.
 ```
 AssertionError: f{func} should not have fake inputs without constants
 ```
-
-[//]: # (Due to these reasons, `lift_fresh.default` must have been suppressed for now in [here]&#40;https://github.com/pytorch/pytorch/blob/ddf36c82b83b2db3be7ce7a85d4aea3507c9d7ef/torch/_dispatch/python.py#L108&#41;)
 

--- a/python/shark_turbine/known_issues.md
+++ b/python/shark_turbine/known_issues.md
@@ -1,24 +1,5 @@
 # Known Issues in SHARK-Turbine
 
-## Handling lists of optional types
-```py
-from torch import nn
-class foomod(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.up = nn.Upsample(scale_factor=2, mode='bilinear', align_corners=True)
-    def forward(self, x):
-        return self.up(x)
-```
-```
-# occuring in importer -> import_list_arguments
-compiler_fn raised TypeError: Heterogeneous lists are not supported: expected <class 'NoneType'>, got <class 'torch.fx.node.Node'>
-```
-An example is attempting to import `nn.Upsample`. This module internally makes a call to `F.interpolate` which eventually 
-calls `aten.index.Tensor` whose [second argument](https://github.com/llvm/torch-mlir/blob/50f5b658b6dc50f664d78c89c403149b064fb59b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td#L7389C46-L7389C46) is an
-optional list of tensors. If indices in a few dimensions are omitted in favor of `None`, we get an error. In reality these values
-should have an `AnyTorchOptionalTensorType` type, we need a way to set optional types when importing lists in this scenario.
-
 
 ## Dealing with functional variants of Torch Ops
 
@@ -35,12 +16,11 @@ compiler_fn raised IndexError: list index out of range
 Currently, we have issues dealing with functional variants of
 torch operations that do not define meaningful defaults for their arguments.
 Two common operations for which this issue arises are `F.avg_pool2d` and `F.max_pool2d`.
-Taking `max_pool2d` as an example, the [functional version](https://pytorch.org/docs/stable/generated/torch.nn.functional.max_pool2d.html) sets `stride=None` by default (which returns an empty list to the importer), 
+Taking `max_pool2d` as an example, the [functional version](https://pytorch.org/docs/stable/generated/torch.nn.functional.max_pool2d.html) sets `stride=None` by default (which returns an empty list to the importer),
 however, the actual intended default setting is to set `stride=kernel_size`. This issue does not occur with the corresponding `nn.Module` wrapper `MaxPool2d` because
 it actually [manually sets the intended default value](https://pytorch.org/docs/stable/_modules/torch/nn/modules/pooling.html#_MaxPoolNd). The same issue is at play in `avg_pool2d`.
 
-
-## Ephemeral Tensor objects from `aten.lift_fresh_copy`
+## Ephemeral Tensor objects from `aten.lift_fresh_copy.default`
 ```py
 def forward(self, x, y):
     x[y == 1] = 2
@@ -53,7 +33,51 @@ This error arises due to an odd case in the Fx Graph generation where the
 graph module for our code generates a node `_tensor_constant0 = self._tensor_constant0` with no traceable origin within
 the graph. This means that our lookup for the appropriate MlirValue in the importer's `_v` table fails. This consistently
 occurs when the graph generates an intermediate `aten.lift_fresh_copy` as in the boolean indexing example above.
-The same error occurs in the expectedFailure test cases of `list(tensor_data)` and `tensor_data.tolist()`.
 
 There is an existing issue in PyTorch that is tracking this problem in the `aot-eager` backend: https://github.com/pytorch/pytorch/issues/105327.
 This issue arises because this particular op is not handled in the PyTorch dispatch logic, and is instead suppresed [here](https://github.com/pytorch/pytorch/blob/ddf36c82b83b2db3be7ce7a85d4aea3507c9d7ef/torch/_dispatch/python.py#L108)
+
+Note that during the test, there wasn't nop_decomposition called.
+
+### Autograd failure in `aten.lift` in the aot_eager, inductor, and turbine backend.
+`aten.lift` is decomposed to `aten.alias`, and then to `view_of`.
+However, AOTAutograd seems to fail in collecting metadata on function when using `aot-eager`, `dynamo`, and `turbine` backend.
+```
+RuntimeError: !at::functionalization::impl::isFunctionalTensor(self) 
+INTERNAL ASSERT FAILED at "../aten/src/ATen/FunctionalizeFallbackKernel.cpp":167, please report a bug to PyTorch. 
+```
+
+### No constants for fake input assertion error in `aten.lift_fresh` and `aten.lift_fresh_copy`
+`lift_fresh` is ONLY called by `torch.Tensor()` call according to native_functions.yaml.
+During dispatch, calling `torch.tensor(x)` will return an empty faketensors (`flat_arg_fake_tensors = []`),
+while while directly calling `lift_fresh` or `lift_fresh_copy` returns faketensor inside faketensors.
+(e.g. `[FakeTensor(FakeTensor(..., device='meta', size=(1,)), cpu)]`).
+
+During the test, there wasn't `nop_decomposition(...)` called contary to test case of calling `aten.lift` directly.
+nop_decomposition() decomposes `aten.detach`, `aten.lift`, `aten.lift_fresh` into `aten.alias`.
+
+This is because `aten.lift_fresh` and `aten.lift_fresh_copy` are functionalized here.
+There's no decomposition of functionalized `aten.lift_fresh` and `aten.lift_fresh_copy` currently.
+Which is why I think inductor is lowering it down to IR. (need to test)
+
+
+
+```python
+def basic_3(x):
+    return torch.tensor(x)
+    # return torch.ops.aten.lift_fresh(x) # this returns some value inside the faketensor
+```
+
+There is also difference between the latest torch and nightly.
+In torch, directly calling `aten.lift_fresh` leads to recursion error.
+```
+`lift_fresh: RecursionError: maximum recursion depth exceeded while calling a Python object`
+```
+In the nightly build, recursion error is fixed by passing in `const args/kwargs`,
+but throws an assertion ero saying that fake inputs should have constants.
+```
+AssertionError: f{func} should not have fake inputs without constants
+```
+
+[//]: # (Due to these reasons, `lift_fresh.default` must have been suppressed for now in [here]&#40;https://github.com/pytorch/pytorch/blob/ddf36c82b83b2db3be7ce7a85d4aea3507c9d7ef/torch/_dispatch/python.py#L108&#41;)
+


### PR DESCRIPTION
Updated progress about Ephemeral Tensor objects from `aten.lift_fresh_copy` case. 
