### PR TITLE
Add more decompositions

### DIFF
--- a/python/shark_turbine/dynamo/passes.py
+++ b/python/shark_turbine/dynamo/passes.py
@@ -20,10 +20,25 @@ DEFAULT_DECOMPOSITIONS = [
     torch.ops.aten.masked_fill.Scalar,
 ]
 
-# decompositions that aid us in handling nn.BatchNorm2d
-BATCHNORM_DECOMPOSITIONS = [
+
+CPU_DECOMPOSITIONS = [
+    # decompositions that aid us in handling nn.BatchNorm2d
     torch.ops.aten._native_batch_norm_legit_functional,
+    torch.ops.aten._native_batch_norm_legit.no_stats,
     torch.ops.aten.squeeze.dims,
+    # decompositions for miscellaneous ops that are not handled in torch-mlir but have available decompositions
+    torch.ops.aten.soft_margin_loss,
+    torch.ops.aten.im2col,
+    torch.ops.aten._euclidean_dist,
+    torch.ops.aten.index_copy,
+    torch.ops.aten.index_copy_,
+    torch.ops.aten.grid_sampler_2d,
+    torch.ops.aten.log_sigmoid_forward,
+    torch.ops.aten.unsafe_split.Tensor,
+    torch.ops.aten.binary_cross_entropy,
+    torch.ops.aten.dot,
+    torch.ops.aten._adaptive_avg_pool2d,
+    torch.ops.aten._prelu_kernel,
 ]
 
 
@@ -45,5 +60,5 @@ def apply_decompositions(
 
 
 def turbine_cpu_pass_pipeline(gm: torch.fx.GraphModule, example_inputs):
-    decompose_ops = DEFAULT_DECOMPOSITIONS + BATCHNORM_DECOMPOSITIONS
+    decompose_ops = DEFAULT_DECOMPOSITIONS + CPU_DECOMPOSITIONS
     return apply_decompositions(gm, example_inputs, decompose_ops)

--- a/python/test/generated/evaluate.py
+++ b/python/test/generated/evaluate.py
@@ -2,6 +2,7 @@ from stats import ErrorAggregatorDict
 import logging
 
 from shark_turbine.dynamo.importer import FxImporter
+from shark_turbine.dynamo.passes import turbine_cpu_pass_pipeline
 import torch
 import torch._dynamo as dynamo
 from torch._dynamo.backends.common import aot_autograd
@@ -9,41 +10,12 @@ from torch.fx import (
     GraphModule,
 )
 
-from torch.fx.experimental.proxy_tensor import make_fx
-from torch._decomp import get_decompositions
-from torch.func import functionalize
-from typing import List
-
-
-def default_decompositions():
-    return get_decompositions(
-        [
-            torch.ops.aten.embedding_dense_backward,
-            torch.ops.aten.native_layer_norm_backward,
-            torch.ops.aten.slice_backward,
-            torch.ops.aten.select_backward,
-            torch.ops.aten.norm.ScalarOpt_dim,
-            torch.ops.aten.native_group_norm,
-            torch.ops.aten.upsample_bilinear2d.vec,
-            torch.ops.aten.split.Tensor,
-            torch.ops.aten.split_with_sizes,
-            torch.ops.aten.native_layer_norm,
-            torch.ops.aten.masked_fill.Tensor,
-            torch.ops.aten.masked_fill.Scalar,
-            torch.ops.aten._native_batch_norm_legit_functional,
-            torch.ops.aten.squeeze.dims,
-        ]
-    )
-
 
 def create_backend():
     imp = FxImporter()
 
     def import_compiler(gm: GraphModule, example_inputs):
-        gm = make_fx(
-            functionalize(gm),
-            decomposition_table=default_decompositions(),
-        )(*example_inputs)
+        gm = turbine_cpu_pass_pipeline(gm, example_inputs)
 
         try:
             imp.import_graph_module(gm)


### PR DESCRIPTION
This addresses a slew of "unimplemented" errors in the test suite for any operations that has an available decomposition. The only exception is `aten.smooth_l1_loss` which, despite having a decomposition available in pytorch, is somehow still triggering the same error - we can investigate this later or implement the op if needed.