### PR TITLE
Address lift fresh copy

### DIFF
--- a/python/shark_turbine/known_issues.md
+++ b/python/shark_turbine/known_issues.md
@@ -21,60 +21,21 @@ it actually [manually sets the intended default value](https://pytorch.org/docs/
 
 ## Ephemeral Tensor objects from `aten.lift_fresh_copy.default`
 ```py
-def forward(self, x, y):
-    x[y == 1] = 2
+import torch
+def forward(self):
+    return torch.tensor([1,2])
 ```
 ```
 # in importer -> import_argument
 torch._dynamo.exc.BackendCompilerFailed: compiler_fn raised KeyError: (_tensor_constant0, 0)
+torch._dynamo.exc.BackendCompilerFailed: compiler_fn raised AssertionError: Can not create literal tensor for unsupported datatype: torch.complex64
 ```
 This error arises due to an odd case in the Fx Graph generation where the
 graph module for our code generates a node `_tensor_constant0 = self._tensor_constant0` with no traceable origin within
-the graph. This means that our lookup for the appropriate MlirValue in the importer's `_v` table fails. This consistently
-occurs when the graph generates an intermediate `aten.lift_fresh_copy` as in the boolean indexing example above.
+the graph. Torch dynamo dynamically creates this attribute in the top level module object, hence this object is never 
+passed through our importer, meaning that our lookup for the appropriate MlirValue in the importer's `_v` table fails. This consistently
+occurs when the graph generates an intermediate `aten.lift_fresh_copy` as in the case of creating a new tensor above.
 
-There is an existing issue in PyTorch that is tracking this problem in the `aot-eager` backend: https://github.com/pytorch/pytorch/issues/105327.
-This issue arises because this particular op is not handled in the PyTorch dispatch logic, and is instead suppresed [here](https://github.com/pytorch/pytorch/blob/ddf36c82b83b2db3be7ce7a85d4aea3507c9d7ef/torch/_dispatch/python.py#L108)
-
-Note that during the test, there wasn't nop_decomposition called.
-
-### Autograd failure in `aten.lift` in the aot_eager, inductor, and turbine backend.
-`aten.lift` is decomposed to `aten.alias`, and then to `view_of`.
-However, AOTAutograd seems to fail in collecting metadata on function when using `aot-eager`, `dynamo`, and `turbine` backend.
-```
-RuntimeError: !at::functionalization::impl::isFunctionalTensor(self) 
-INTERNAL ASSERT FAILED at "../aten/src/ATen/FunctionalizeFallbackKernel.cpp":167, please report a bug to PyTorch. 
-```
-
-### No constants for fake input assertion error in `aten.lift_fresh` and `aten.lift_fresh_copy`
-`lift_fresh` is ONLY called by `torch.Tensor()` call according to native_functions.yaml.
-During dispatch, calling `torch.tensor(x)` will return an empty faketensors (`flat_arg_fake_tensors = []`),
-while while directly calling `lift_fresh` or `lift_fresh_copy` returns faketensor inside faketensors.
-(e.g. `[FakeTensor(FakeTensor(..., device='meta', size=(1,)), cpu)]`).
-
-During the test, there wasn't `nop_decomposition(...)` called contary to test case of calling `aten.lift` directly.
-nop_decomposition() decomposes `aten.detach`, `aten.lift`, `aten.lift_fresh` into `aten.alias`.
-
-This is because `aten.lift_fresh` and `aten.lift_fresh_copy` are functionalized here.
-There's no decomposition of functionalized `aten.lift_fresh` and `aten.lift_fresh_copy` currently.
-When using `inductor`, these ops are transformed to `aten.clone` and lowered down to IR.
-
-TODO: Figure out how `aten.lift_fresh` and `aten.lift_fresh_copy` works in `eager` mode.
-
-```python
-def basic_3(x):
-    return torch.tensor(x)
-    # return torch.ops.aten.lift_fresh(x) # this returns some value inside the faketensor
-```
-
-There is also difference between the latest torch and nightly.
-In torch, directly calling `aten.lift_fresh` leads to recursion error.
-```
-`lift_fresh: RecursionError: maximum recursion depth exceeded while calling a Python object`
-```
-In the nightly build, recursion error is fixed by passing in `const args/kwargs`,
-but throws an assertion ero saying that fake inputs should have constants.
-```
-AssertionError: f{func} should not have fake inputs without constants
-```
-
+We now have a fix for this by directly instantiating the object using a reference to the top level graph module in the 
+importer, but this method does not support all torch datatypes - in particular it fails to support `bfloat16` and 
+complex datatypes.

--- a/python/test/dynamo/importer_basic_test.py
+++ b/python/test/dynamo/importer_basic_test.py
@@ -3,6 +3,7 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import torch
 
 from testutils import *
 
@@ -126,36 +127,23 @@ class ImportTests(unittest.TestCase):
         t = torch.randn([4, 4, 4, 4])
         opt(t)
 
-    @unittest.expectedFailure
-    def testImportToList(self):
-        """
-        Marked as XFail due to No stacktrace found for _tensor_constant0 = self._tensor_constant0
-        that leads to copy of None in aten.lift_fresh_copy op and fails to get operands
-        This is due to PyTorch suppressing functionalization of this particular op
-        """
-
+    def testLiftFreshCopy(self):
         def foo():
-            tensor_data = torch.tensor([[1, 2, 3], [4, 5, 6]])
-            list_data = tensor_data.tolist()
-            return list_data
+            w = torch.tensor([[1,2], [3,4]], dtype=torch.uint8)
+            x = torch.tensor([[1,2], [3,4]], dtype=torch.int32)
+            y = torch.tensor([[1,2], [3,4]], dtype=torch.float32)
+            z = torch.tensor([[1,2], [3,4]], dtype=torch.float64)
+            return w, x, y, z
 
         opt_foo = torch.compile(foo, backend=create_backend())
-        result = opt_foo()
-        expected_result = foo()
-        self.assertEqual(result, expected_result, "broken")
+        opt_foo()
 
     @unittest.expectedFailure
-    def testImportStandardList(self):
-        """
-        Marked as XFail due to No stacktrace found for _tensor_constant0 = self._tensor_constant0
-        that leads to copy of None in aten.lift_fresh_copy op and fails to get operands
-        This is due to PyTorch suppressing functionalization of this particular op
-        """
-
+    def testLiftFreshCopyComplex(self):
         def foo():
-            tensor_data = torch.tensor([[1, 2, 3], [4, 5, 6]])
-            list_data = list(tensor_data)
-            return list_data
+            x = torch.tensor([[1,2], [3,4]], dtype=torch.complex64)
+            y = torch.tensor([[1,2], [3,4]], dtype=torch.complex128)
+            return x, y
 
         opt_foo = torch.compile(foo, backend=create_backend())
         opt_foo()


### PR DESCRIPTION
This PR implements a workaround to the issues we face as a result of lift_fresh_copy. This op is generated to guarantee the freshness invariant of a new tensor (see [here](https://github.com/pytorch/pytorch/blob/8c62f01cb7b75cb647882a9bf85f10031b08896e/torch/fx/experimental/proxy_tensor.py#L329)). FX actually takes constant tensor objects from operations like `torch.Tensor([2.])` and [creates uniquely named attributes](https://github.com/pytorch/pytorch/blob/36399d067a56d9875fd9c2bf61434126398ffb87/torch/fx/graph.py#L843C56-L843C56) in the top level module to store their values, hence these values never touch Turbine's importer (this is also why there is an apparent graph break at these operations, they're referencing something that wasn't created in the user-defined function). Dynamo then represents these constant values with a `get_attr` node that seeks to retrieve the object associated with that name from the top level module.

The fix implemented here is simple: catch when this occurs, grab the actual object from the top level module, and create an entry in our importer's `_v` table so that we can properly associate the identifier generated by FX with the appropriate `MlirValue`. To do this we construct a `torch.vtensor.literal` op which requires an `ElementsAttr` as input. `ElementsAttr` requires a python buffer to create the corresponding mlir `tensor` object. However, there is an issue: torch `Tensor` objects do not currently implement the full python array interface so they can't be directly converted into a python buffer (see this [issue](https://github.com/pytorch/pytorch/issues/51156) and [this article](https://pearu.github.io/array_interface_pytorch.html)). So we have to convert the tensor to numpy in order to get a buffer version of our tensor. 

It's possible I overcomplicated this last part, and it has the unfortunate side effect that we can't do this for `bfloat16` (because this type doesn't exist in numpy) or `torch.complex` datatypes (because the numpy buffer format for these objects is incompatible with the buffer format `DenseElementsAttr` is expecting for complex datatypes - so if there's a better way to do this I'd love to implement it that way instead.

Generated tests are now at 90% passing.