### PR TITLE
Add sequential option for generated tests

### DIFF
--- a/python/test/generated/main.py
+++ b/python/test/generated/main.py
@@ -22,7 +22,7 @@ def get_args(raw_args=None):
         "-j",
         type=int,
         default=4,
-        help="Number of threads in our threadpool, jobs=1 is essentially sequential execution",
+        help="Number of threads in our threadpool, ignored if --sequential is set",
     )
     parser.add_argument(
         "--offset",
@@ -39,6 +39,11 @@ def get_args(raw_args=None):
         "--tests-dir",
         default=None,
         help="jit-paritybench location (i.e. /path/to/pytorch-jit-paritybench)",
+    )
+    parser.add_argument(
+        "--sequential",
+        action="store_true",
+        help="Set to run tests sequentially without threading, this can help resolve hanging or long runtimes due to low memory",
     )
     # parser.add_argument("--device", default="cuda", type=str, help="evaluate modules using cuda or cpu") # excluded for now as we only have turbine-cpu, can use this later
 

--- a/python/test/generated/testutils.py
+++ b/python/test/generated/testutils.py
@@ -190,12 +190,19 @@ def evaluate_all(
         testfiles = testfiles[offset : offset + limit]
 
     with tqdm(total=len(testfiles)) as pbar:
-        pool = ThreadPool(jobs)
-        for errors_part, stats_part in pool.imap_unordered(fn, testfiles):
-            errors.update(errors_part)
-            stats.update(stats_part)
-            pbar.update()
-        pool.close()
+        if args.sequential:
+            for file in testfiles:
+                errors_part, stats_part = fn(path=file)
+                errors.update(errors_part)
+                stats.update(stats_part)
+                pbar.update()
+        else:
+            pool = ThreadPool(jobs)
+            for errors_part, stats_part in pool.imap_unordered(fn, testfiles):
+                errors.update(errors_part)
+                stats.update(stats_part)
+                pbar.update()
+            pool.close()
 
     errors.print_report()
     log.info(f"Total time: {time.time() - start:02f} s")


### PR DESCRIPTION
Adds the ability to run tests sequentially in case python threading poses problems for certain machines.