### PR TITLE
Fix aten full decomposition

### DIFF
--- a/python/shark_turbine/dynamo/passes.py
+++ b/python/shark_turbine/dynamo/passes.py
@@ -39,6 +39,7 @@ CPU_DECOMPOSITIONS = [
     torch.ops.aten.dot,
     torch.ops.aten._adaptive_avg_pool2d,
     torch.ops.aten._prelu_kernel,
+    torch.ops.aten.full,
 ]
 
 

--- a/python/test/dynamo/importer_basic_test.py
+++ b/python/test/dynamo/importer_basic_test.py
@@ -241,6 +241,14 @@ class ImportTests(unittest.TestCase):
         opt = torch.compile(mod, backend=create_backend())
         opt(torch.randn(1, 1, 256, 256))
 
+    @unittest.expectedFailure
+    def testImportAtenFull(self):
+        """Expected to fail until torch-mlir op: torch.aten.empty_strided is implemented """
+        def foo(x):
+            return torch.full(x.size(), fill_value=float('-inf'))
+
+        opt_foo = torch.compile(foo, backend='turbine_cpu')
+        opt_foo(torch.randn(2, 3))
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
A quick fix to decompose `aten.full` by adding it to CPU decomposition in Turbine. 