### PR TITLE
Extract unimplemented ops from generated test suite

### DIFF
--- a/python/test/generated/extract_unimpl_ops.sh
+++ b/python/test/generated/extract_unimpl_ops.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python main.py --limit 500 -j 8 | grep "NotImplementedError: Unimplemented torch op in the IREE compiler" | grep -o "'[^']*'" | sed "s/'//g" > unimplemented_torch_ops.txt

--- a/python/test/generated/running_tests.md
+++ b/python/test/generated/running_tests.md
@@ -19,6 +19,13 @@ Once everything is set up in your conda environment we can run the test suite us
 
 To speed up iteration on tests it's recommended to make use of the `offset`, `limit`, and `filter` arguments as running the full test suite can take some time.
 
+## Unimplemented Torch Ops
+Many of the errors in our test suite will arise due to unimplemented ops in torch-mlir, we can use the `extract_unimpl_ops.sh` script to extract a list of these ops:
+```bash
+python main.py --limit 500 -j 8 | grep "NotImplementedError: Unimplemented torch op in the IREE compiler" | grep -o "'[^']*'" | sed "s/'//g" > unimplemented_torch_ops.txt
+```
+
+
 ## Help
 ```
 usage: main.py [-h] [--jobs JOBS] [--offset OFFSET] [--limit LIMIT] [--filter FILTER] [--skips SKIPS] [--tests-dir TESTS_DIR]


### PR DESCRIPTION
Adds a utility script to get a list of unimplemented torch ops from torch-mlir using our test suite.