### PR TITLE
Replace lift_fresh_copy with aten.clone

### DIFF
--- a/python/shark_turbine/dynamo/importer.py
+++ b/python/shark_turbine/dynamo/importer.py
@@ -415,6 +415,9 @@ class GraphNodeImporter:
         if target == torch.ops.aten.lift_fresh_copy.default:
             node.target = target = torch.ops.aten.clone.default
             node.args = (node.args[0], None)
+        elif target == torch.ops.aten.lift_fresh_copy.out:
+            node.target = target = torch.ops.aten.clone.out
+            node.args = (node.args[0], None, node.args[1])
 
         schema = target._schema
         assert isinstance(schema, FunctionSchema)

--- a/python/shark_turbine/dynamo/importer.py
+++ b/python/shark_turbine/dynamo/importer.py
@@ -411,6 +411,11 @@ class GraphNodeImporter:
     def _import_torch_op_overload(
         self, loc: Location, node: torch_fx.Node, target: TorchOpOverload
     ):
+        # replace lift_fresh_copy with clone op
+        if target == torch.ops.aten.lift_fresh_copy.default:
+            node.target = target = torch.ops.aten.clone.default
+            node.args = (node.args[0], None)
+
         schema = target._schema
         assert isinstance(schema, FunctionSchema)
 


### PR DESCRIPTION
Previously we had a fix that allowed us to pass `lift_fresh_copy` through the importer. However, this fails to actually lower to `linalg` and then `arith` due to an issue in `torch-mlir` where `lift_fresh_copy` causes a failure in the corresponding lowering passes when using torch dynamo, this is a quick fix that replaces this op with an equivalent one: `aten.clone`. This is valid because this is actually the canonical decomposition of `lift_fresh_copy` in `torch-mlir` anyway.