### PR TITLE
Promote scalar arguments to tensors when appropriate

### DIFF
--- a/python/shark_turbine/dynamo/importer.py
+++ b/python/shark_turbine/dynamo/importer.py
@@ -581,7 +581,12 @@ class GraphNodeImporter:
             isinstance(node.args[1], float) or isinstance(node.args[1], int)
         ):
             mlir_op_name = TENSOR_SCALAR_OP_CONVERTER[mlir_op_name]
-            # replace schema to retrieve the right function signature
+            # we are dynamically changing which op is emitted here due to an issue in
+            # torch dynamo where it emits the Tensor variant of ops even when processing
+            # scalar arguments, therefore we retrieve the schema as well so that we
+            # consume the correct typing information when subsequently importing the
+            # function arguments and result types
+            # i.e. the code below is basically doing `schema = torch.ops.aten.my_op.Scalar._schema`
             op_attrs = mlir_op_name.split(".")
             op_overload = getattr(torch, "ops")
             for i in range(1, len(op_attrs)):

--- a/python/test/dynamo/importer_basic_test.py
+++ b/python/test/dynamo/importer_basic_test.py
@@ -96,6 +96,17 @@ class ImportTests(unittest.TestCase):
         opt_foo = torch.compile(foo, backend=create_backend())
         opt_foo(torch.randn(4, 4, 4, 4))
 
+    def testPromoteScalarTensor(self):
+        """
+        Test whether scalar arguments are properly promoted to 0-rank Tensors for torch ops with no Scalar equivalent
+        """
+
+        def foo(x):
+            return torch.ops.aten.div.Tensor_mode(x, 14, rounding_mode="floor")
+
+        opt_foo = torch.compile(foo, backend=create_backend())
+        opt_foo(torch.randn(4, 4, 4, 4))
+
     def testImportDecomposeChunk(self):
         def foo_chunk(x):
             return torch.chunk(x, 2, dim=-1)
@@ -243,12 +254,14 @@ class ImportTests(unittest.TestCase):
 
     @unittest.expectedFailure
     def testImportAtenFull(self):
-        """Expected to fail until torch-mlir op: torch.aten.empty_strided is implemented """
-        def foo(x):
-            return torch.full(x.size(), fill_value=float('-inf'))
+        """Expected to fail until torch-mlir op: torch.aten.empty_strided is implemented"""
 
-        opt_foo = torch.compile(foo, backend='turbine_cpu')
+        def foo(x):
+            return torch.full(x.size(), fill_value=float("-inf"))
+
+        opt_foo = torch.compile(foo, backend="turbine_cpu")
         opt_foo(torch.randn(2, 3))
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
Handles a case where there is no `Scalar` equivalent for a torch op which accepts scalar arguments - instead Pytorch promotes such scalars to a 0-rank tensor, which we now do as well.