### PR TITLE
Implement programming model for AOT parameters and globals.

### DIFF
--- a/python/shark_turbine/aot/builder.py
+++ b/python/shark_turbine/aot/builder.py
@@ -5,23 +5,39 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Sequence, Tuple
+from typing import Any, Callable, Dict, Generator, Optional, Sequence, Tuple
 
 import logging
+import weakref
+
+import numpy as np
+import torch
 
 from iree.compiler.ir import (
     Context,
+    DenseElementsAttr,
     FunctionType,
     InsertionPoint,
     Location,
     Operation,
     StringAttr,
     SymbolTable,
-    Type,
+    Type as IrType,
+    TypeAttr,
+    UnitAttr,
+    # Types.
+    ComplexType,
+    BF16Type,
+    F16Type,
+    F32Type,
+    F64Type,
+    IntegerType,
+    RankedTensorType,
 )
 
 from iree.compiler.dialects import (
     func as func_d,
+    util as util_d,
 )
 
 from ..dynamo.importer import (
@@ -30,17 +46,126 @@ from ..dynamo.importer import (
 
 logger = logging.getLogger("shark_turbine.aot")
 
+# When emitting constants, we have to create native IREE types.
+TORCH_DTYPE_TO_IREE_TYPE: Dict[str, Callable[[], IrType]] = {
+    torch.float16: lambda: F16Type.get(),
+    torch.bfloat16: lambda: BF16Type.get(),
+    torch.float32: lambda: F32Type.get(),
+    torch.float64: lambda: F64Type.get(),
+    torch.uint8: lambda: IntegerType.get_signless(8),
+    torch.int8: lambda: IntegerType.get_signless(8),
+    torch.int16: lambda: IntegerType.get_signless(16),
+    torch.int32: lambda: IntegerType.get_signless(32),
+    torch.int64: lambda: IntegerType.get_signless(64),
+    torch.bool: lambda: IntegerType.get_signless(1),
+    torch.qint8: lambda: IntegerType.get_signless(8),
+    torch.quint8: lambda: IntegerType.get_signless(8),
+    torch.complex32: lambda: ComplexType.get(F16Type.get()),
+    torch.complex64: lambda: ComplexType.get(F32Type.get()),
+    torch.complex128: lambda: ComplexType.get(F64Type.get()),
+}
+
+
+# Opaque value to indicate something is empty. Used in cases where 'None'
+# may have a different meaning.
+_Empty = object()
+
+
+class RefMapping:
+    __slots__ = [
+        "_referrent",
+        "value",
+    ]
+
+    def __init__(self, referrent: Any):
+        if referrent is not _Empty:
+            self._referrent = weakref.ref(referrent)
+        self.value = _Empty
+
+    @property
+    def is_empty(self):
+        return self.value is _Empty
+
+    def __repr__(self):
+        return (
+            f"<RefMapping {id(self._referrent) if self._referrent is not _Empty else 'empty'} -> "
+            f"{self.value if self.value is not _Empty else 'empty'}>"
+        )
+
+
+class RefTracker:
+    """Tracks live references from Python values to symbolic associations."""
+
+    def __init__(self):
+        self._refs: Dict[int, RefMapping] = {}
+
+    def track(self, referrent: Any) -> RefMapping:
+        ref_id = id(referrent)
+        existing = self._refs.get(ref_id)
+        if existing:
+            return existing
+        info = RefMapping(referrent)
+        if referrent is not _Empty:
+            weakref.finalize(referrent, self._ref_finalizer, ref_id)
+        self._refs[ref_id] = info
+        return info
+
+    def _ref_finalizer(self, ref_id: int):
+        del self._refs[ref_id]
+
+
+class GlobalsDef:
+    """Base class for all exporting descriptors."""
+
+    __slots__ = []
+
+    def items(self) -> Generator[Tuple[str, Any], None, None]:
+        """Yields tuples of name/value exports."""
+        raise NotImplementedError
+
+
+class MaterializedGlobal:
+    """Associates a (possibly) materialized global with a name hint and info for the aggregate it is part of."""
+
+    __slots__ = [
+        "global_op",
+        "global_type",
+        "info",
+        "export_name",
+        "symbol_name",
+    ]
+
+    def __init__(
+        self,
+        export_name: str,
+        info: GlobalsDef,
+        *,
+        symbol_name: str,
+        global_op: Operation,
+        global_type: IrType,
+    ):
+        self.info = info
+        self.export_name = export_name
+        self.symbol_name = symbol_name
+        self.global_op = global_op
+        self.global_type = global_type
+
+    def __repr__(self):
+        return f"<MaterializedGlobal {self.export_name} = {self.symbol_name}:{self.global_type}>"
+
 
 class ModuleBuilder:
     """Wrapper around module and IR accounting for a module being built."""
 
     __slots__ = [
         "body",
+        "cache",
         "context",
+        "global_ip",
+        "ip",
         "module_op",
         "symbol_table",
-        "ip",
-        "cache",
+        "global_ref_tracker",
     ]
 
     def __init__(self, module_op: Operation):
@@ -48,8 +173,11 @@ class ModuleBuilder:
         self.context = module_op.context
         self.body = module_op.regions[0].blocks[0]
         self.symbol_table = SymbolTable(module_op)
+        self.global_ip = InsertionPoint.at_block_begin(self.body)
         self.ip = InsertionPoint(self.body)
         self.cache = ContextCache(self.context)
+        # Tracks global references to a MaterializedGlobal.
+        self.global_ref_tracker = RefTracker()
 
     def finalize_construct(self):
         self.module_op.verify()
@@ -57,7 +185,7 @@ class ModuleBuilder:
     def create_func_op(
         self,
         symbol_name: str,
-        argument_types: Sequence[Type],
+        argument_types: Sequence[IrType],
         is_public: bool = True,
         add_entry_block: bool = True,
     ) -> Tuple[str, func_d.FuncOp]:
@@ -71,3 +199,71 @@ class ModuleBuilder:
             self.symbol_table.insert(func_op)
             actual_symbol_name = StringAttr(func_op.attributes["sym_name"]).value
             return actual_symbol_name, func_op
+
+    def torch_dtype_to_iree_type(self, dtype: torch.dtype) -> IrType:
+        try:
+            with self.context:
+                return TORCH_DTYPE_TO_IREE_TYPE[dtype]()
+        except KeyError:
+            raise TypeError(f"Could not map Torch dtype {dtype} to an IREE type")
+
+    def create_tensor_global(
+        self,
+        symbol_name: str,
+        t: torch.Tensor,
+        *,
+        mutable: bool = False,
+        initial_value: bool = True,
+        noinline: bool = True,
+    ) -> Tuple[str, Operation, IrType]:
+        element_type = self.torch_dtype_to_iree_type(t.dtype)
+        with self.global_ip, Location.unknown():
+            tensor_type = RankedTensorType.get(list(t.shape), element_type)
+            attrs = {
+                "sym_name": StringAttr.get(symbol_name),
+                "sym_visibility": StringAttr.get("private"),
+                "type": TypeAttr.get(tensor_type),
+            }
+            if noinline:
+                attrs["noinline"] = UnitAttr.get()
+            if mutable:
+                attrs["is_mutable"] = UnitAttr.get()
+            if initial_value:
+                detached_tensor = t.detach().contiguous().cpu()
+                array = np.array(detached_tensor)
+                contents = memoryview(array)
+                # TODO: Add resource elements to Python API and use that.
+                elements_attr = DenseElementsAttr.get(contents, type=tensor_type)
+                attrs["initial_value"] = elements_attr
+
+            global_op = Operation.create("util.global", attributes=attrs)
+            self.symbol_table.insert(global_op)
+            actual_symbol_name = StringAttr(global_op.attributes["sym_name"]).value
+            return actual_symbol_name, global_op, tensor_type
+
+    def track_globals(self, export_namespace: str, globals_def: GlobalsDef):
+        for name, value in globals_def.items():
+            # Switch on types we support.
+            if isinstance(value, torch.Tensor):
+                fq_name = f"{export_namespace}.{name}"
+                mapping = self.global_ref_tracker.track(value)
+                if not mapping.is_empty:
+                    logging.debug(
+                        "IGNORE EXISTING TRACKED TENSOR(%s): %r", fq_name, mapping
+                    )
+                    continue
+                actual_symbol_name, global_op, global_type = self.create_tensor_global(
+                    f"_{fq_name}", value
+                )
+                mapping.value = MaterializedGlobal(
+                    fq_name,
+                    globals_def,
+                    symbol_name=actual_symbol_name,
+                    global_op=global_op,
+                    global_type=global_type,
+                )
+                # TODO: Handle GlobalsDef that request non-lazy instantiation.
+                logging.debug("TRACK NEW TENSOR(%s): %r", fq_name, mapping)
+                continue
+
+            raise TypeError(f"Unsupported global type: {value.__class__}")

--- a/python/shark_turbine/aot/builtins/__init__.py
+++ b/python/shark_turbine/aot/builtins/__init__.py
@@ -4,10 +4,13 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from .globals import *
 from .jittable import jittable
 from .typedef import *
 
 __all__ = [
-    "jittable",
     "AbstractTensor",
+    "export_global",
+    "export_parameters",
+    "jittable",
 ]

--- a/python/shark_turbine/aot/builtins/globals.py
+++ b/python/shark_turbine/aot/builtins/globals.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Nod Labs, Inc
+# Portions Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Any
+
+import torch.nn as nn
+
+from ..builder import GlobalsDef
+
+
+class export_global(GlobalsDef):
+    """Exports a single global into a CompiledModule."""
+
+    __slots__ = ["_name", "_value"]
+
+    def __init__(self, value: Any, *, name: str = "global"):
+        self._name = name
+        self._value = value
+
+    def items(self):
+        yield (self._name, self._value)
+
+
+class export_parameters(GlobalsDef):
+    """Exports parameters from an nn.Module."""
+
+    def __init__(self, nn_module: nn.Module):
+        self._param_list = list(nn_module.named_parameters())
+
+    def items(self):
+        for name, value in self._param_list:
+            yield (name, value)
+
+    def __repr__(self):
+        names = [name for name, _ in self._param_list]
+        return f"<export_parameters {', '.join(names)}>"

--- a/python/shark_turbine/aot/builtins/typedef.py
+++ b/python/shark_turbine/aot/builtins/typedef.py
@@ -17,7 +17,10 @@ from iree.compiler.ir import (
     Value,
 )
 
-from ..builder import ModuleBuilder
+from ..builder import (
+    ModuleBuilder,
+)
+
 from ..procedural import (
     AbstractIntrinsic,
     Intrinsic,
@@ -64,12 +67,8 @@ class AbstractTensor(AbstractIntrinsic):
         return IrValueTensor(ir_value, self.dtype)
 
     def get_ir_type(self, builder: ModuleBuilder) -> IrType:
-        try:
-            dtype_asm = TORCH_DTYPE_TO_IREE_TYPE_ASM[self.dtype]
-        except KeyError:
-            raise KeyError(f"Could not map Torch dtype {self.dtype} to an IREE type")
+        element_type = builder.torch_dtype_to_iree_type(self.dtype)
         with Location.unknown(builder.context):
-            element_type = IrType.parse(dtype_asm)
             tensor_type = RankedTensorType.get(
                 [s if s is not None else -1 for s in self.size], element_type
             )

--- a/python/shark_turbine/aot/procedural.py
+++ b/python/shark_turbine/aot/procedural.py
@@ -282,7 +282,14 @@ class IrTensorBase(Intrinsic):
         assert not any(
             d < 0 for d in shape
         ), "Dynamic dims to jittable not yet implemented"
-        return torch.empty(shape, dtype=self.dtype, device="meta")
+
+        # TODO: We shouldn't need to create a real tensor here, as Dynamo will
+        # immediately convert it to fake. However, it will also set up the shape
+        # environment and asserts that any fake tensor inputs are from its
+        # internal FakeMode. There should be a way but needs more investigation.
+        # TODO: This tensor needs a device that matches the model being exported.
+        # We just create these on the CPU because that is common.
+        return torch.empty(shape, dtype=self.dtype)
 
 
 class IrValueTensor(IrTensorBase):

--- a/python/shark_turbine/dynamo/passes.py
+++ b/python/shark_turbine/dynamo/passes.py
@@ -2,7 +2,7 @@ import torch
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch._decomp import get_decompositions
 from torch.func import functionalize
-from typing import List
+from typing import Dict, List
 
 # default decompositions pulled from SHARK
 DEFAULT_DECOMPOSITIONS = [
@@ -18,6 +18,8 @@ DEFAULT_DECOMPOSITIONS = [
     torch.ops.aten.native_layer_norm,
     torch.ops.aten.masked_fill.Tensor,
     torch.ops.aten.masked_fill.Scalar,
+    torch.ops.aten.t,
+    torch.ops.aten.addmm,
 ]
 
 

--- a/python/test/aot/globals_test.py
+++ b/python/test/aot/globals_test.py
@@ -1,0 +1,49 @@
+# Copyright 2023 Nod Labs, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+import unittest
+
+from iree.compiler.ir import (
+    Context,
+)
+
+from shark_turbine.aot import *
+
+import torch
+import torch.nn as nn
+
+
+class SimpleParams(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.classifier = nn.Linear(20, 30)
+
+    def forward(self, x):
+        return self.classifier(x)
+
+
+class ArgsTest(unittest.TestCase):
+    def testGlobalParameters(self):
+        m = SimpleParams()
+
+        class GlobalModule(CompiledModule):
+            params = export_parameters(m)
+            compute = jittable(m.forward)
+
+            def run(self, x=AbstractTensor(128, 20)):
+                return self.compute(x)
+
+        inst = GlobalModule(context=Context())
+        module_str = str(CompiledModule.get_mlir_module(inst))
+        print(module_str)
+        self.assertIn("util.global private @_params.classifier.weight", module_str)
+        self.assertIn("util.global private @_params.classifier.bias", module_str)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()


### PR DESCRIPTION
* Introduces `export_parameters` which eagerly generates IR for accessing module parameters. Currently it is just emitting a global for each with an initial value, but this can be controlled with kwargs for more advanced policies.
* Teaches the AOT module builder how to track captured tensors by reference and repatriate them with the module level globals during import.
* Adds a hook to the FxImporter that lets us take control of how to materialize access to py values (other than the default policy of just freezing them as inline constants).
* Switches the AOT pipeline to use a new `torch-to-iree-pipeline`, which is needed in IREE because with these changes, we have deviated from what Torch-MLIR upstream calls "linalg lowering" and need to make alterations. (Needs a patch to land in IREE to use)
* Has the plumbing to allow procedural access to the parameters but isn't fully exposed yet (will currently only work with implicit access to tracked parameters from a jittable).

Requires patch: https://github.com/openxla/iree/pull/14971