### PR TITLE
Start building out IREE procedural meta-language.

### DIFF
--- a/python/shark_turbine/aot/builtins/__init__.py
+++ b/python/shark_turbine/aot/builtins/__init__.py
@@ -6,10 +6,28 @@
 
 from .globals import *
 from .jittable import jittable
-from ..support.procedural import AbstractTensor, abstractify
+from ..support.procedural import (
+    AbstractBool,
+    AbstractF32,
+    AbstractF64,
+    AbstractI32,
+    AbstractI64,
+    AbstractIndex,
+    AbstractTensor,
+    abstractify,
+)
+
+from .iree_ir import IREE
 
 __all__ = [
+    "AbstractBool",
+    "AbstractF32",
+    "AbstractF64",
+    "AbstractI32",
+    "AbstractI64",
+    "AbstractIndex",
     "AbstractTensor",
+    "IREE",
     "abstractify",
     "export_global",
     "export_global_tree",

--- a/python/shark_turbine/aot/builtins/iree_ir.py
+++ b/python/shark_turbine/aot/builtins/iree_ir.py
@@ -1,0 +1,179 @@
+# Copyright 2023 Nod Labs, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Python API for IREE's high-level tensor dialects."""
+
+from typing import Any, List, Sequence, Tuple, Union
+
+import functools
+
+import torch
+
+from ..support.ir_imports import (
+    IndexType,
+    RankedTensorType,
+    StringAttr,
+    Value,
+    flow_d,
+)
+
+from ..support.ir_utils import (
+    TORCH_DTYPE_TO_IREE_TYPE,
+    build_index_value,
+)
+
+from ..support.procedural import (
+    AbstractScalar,
+    AbstractTensor,
+    Intrinsic,
+    IrValueTensor,
+    IrValueScalar,
+    current_ir_trace,
+    _ShapedTypeDynamicSizeSentinel,
+)
+
+BuildableScalarValue = Union[IrValueScalar, Value]
+BuildableTensorDimDecl = Union[int, Value]
+BuildableTensorType = IrValueTensor
+BuildableIndexType = Union[Value, int]
+StaticIndexType = int
+
+
+def cast_scalar_value(x: BuildableScalarValue) -> Value:
+    x = unwrap_intrinsic_value(x)
+    if not isinstance(x, Value):
+        raise ValueError(f"Expected a scalar value but got {x}")
+    return x
+
+
+def cast_tensor_value(x: BuildableTensorType) -> IrValueTensor:
+    assert isinstance(x, IrValueTensor), f"Expected a tensor but got {type(x)}"
+    return x
+
+
+def cast_index_value(x: BuildableIndexType) -> Value:
+    if isinstance(x, int):
+        return build_index_value(x)
+    else:
+        return x
+
+
+def cast_static_bounded_index(x: int, min_value: int, max_value: int) -> int:
+    if not isinstance(x, int):
+        raise ValueError(f"Expected int but got {type(x)}")
+    if x < min_value or x > max_value:
+        raise ValueError(
+            f"Expected int in range [{min_value}, {max_value}] but got {x}"
+        )
+    return x
+
+
+def cast_tensor_dim_decl(
+    xs: Sequence[BuildableTensorDimDecl],
+) -> Tuple[Sequence[int], Sequence[Value]]:
+    """Casts a sequence of tensor declaration dimensions to dims suitable
+    for construction of a TensorType and a sequence of dynamic dim values."""
+    dim_decls: List[int] = []
+    dynamic_dim_values: List[Value] = []
+    for x in xs:
+        x = unwrap_intrinsic_value(x)
+        if isinstance(x, Value):
+            assert_value_is_index(x)
+            dim_decls.append(_ShapedTypeDynamicSizeSentinel)
+            dynamic_dim_values.append(x)
+        elif isinstance(x, int) and x >= 0:
+            dim_decls.append(x)
+        else:
+            raise ValueError(
+                f"Expected a tensor dimension as a positive integer or None but got {x}"
+            )
+    return dim_decls, dynamic_dim_values
+
+
+def assert_value_is_index(x: Value):
+    t = x.type
+    if not IndexType.isinstance(t):
+        raise ValueError(f"Expected an index value but got {t}")
+
+
+def unwrap_intrinsic_value(x) -> Any:
+    if isinstance(x, Intrinsic):
+        x, *rest = x.resolve_ir_values(current_ir_trace())
+        if rest:
+            raise ValueError(
+                f"Expected a value that has an arity of one component but for {len(rest) + 1}"
+            )
+    return x
+
+
+def emitter(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        t = current_ir_trace()
+        with t.loc, t.ip:
+            return f(*args, **kwargs)
+
+    return wrapper
+
+
+class IREEBuilder:
+    @emitter
+    def tensor_dim(self, source: BuildableTensorType, index: int) -> IrValueScalar:
+        """Gets the dimension size of a tensor at a static position."""
+        source = cast_tensor_value(source)
+        index = cast_static_bounded_index(index, 0, source.rank - 1)
+        return IrValueScalar(source.get_dim_value(index))
+
+    @emitter
+    def tensor_empty(
+        self, *dims: BuildableTensorDimDecl, dtype: torch.dtype = torch.float32
+    ) -> IrValueTensor:
+        """Constructs a tensor with uninitialized values.
+
+        TODO: Support an IREE/raw element type in addition to the torch dtype.
+        """
+        dim_decls, dyn_dim_values = cast_tensor_dim_decl(dims)
+        try:
+            element_type = TORCH_DTYPE_TO_IREE_TYPE[dtype]()
+        except KeyError:
+            raise ValueError(f"Could not map Torch dtype {dtype} to an IREE type")
+        tensor_type = RankedTensorType.get(dim_decls, element_type)
+        raw_tensor = flow_d.TensorEmptyOp(tensor_type, dyn_dim_values).result
+        result = IrValueTensor(raw_tensor, dtype=dtype)
+        result.set_dynamic_dim_values(dyn_dim_values)
+        return result
+
+    @emitter
+    def tensor_splat(
+        self,
+        *dims: BuildableTensorDimDecl,
+        value: BuildableScalarValue,
+        dtype: torch.dtype,
+    ) -> IrValueTensor:
+        # TODO: Type infer the dtype if missing.
+        dim_decls, dyn_dim_values = cast_tensor_dim_decl(dims)
+        try:
+            element_type = TORCH_DTYPE_TO_IREE_TYPE[dtype]()
+        except KeyError:
+            raise ValueError(f"Could not map Torch dtype {dtype} to an IREE type")
+        value = cast_scalar_value(value)
+        if value.type != element_type:
+            raise ValueError(
+                f"Provided splat value ({type(value)}) does not match dtype {dtype}"
+            )
+        tensor_type = RankedTensorType.get(dim_decls, element_type)
+        raw_tensor = flow_d.TensorSplatOp(tensor_type, value, dyn_dim_values).result
+        result = IrValueTensor(raw_tensor, dtype=dtype)
+        result.set_dynamic_dim_values(dyn_dim_values)
+        return result
+
+    @emitter
+    def tensor_trace(self, key: str, *ts: BuildableTensorType):
+        ts = [cast_tensor_value(t).ir_value for t in ts]
+        flow_d.TensorTraceOp(StringAttr.get(key), ts)
+
+
+IREE = IREEBuilder()

--- a/python/shark_turbine/aot/support/ir_imports.py
+++ b/python/shark_turbine/aot/support/ir_imports.py
@@ -8,16 +8,22 @@
 """Unifies all imports of iree.compiler.ir into one place."""
 
 from iree.compiler.ir import (
+    Block,
+    BlockArgument,
     Context,
     DenseElementsAttr,
     FlatSymbolRefAttr,
     FunctionType,
+    IndexType,
     InsertionPoint,
+    IntegerAttr,
     Location,
     MLIRError,
     Module,
+    OpResult,
     Operation,
     RankedTensorType,
+    ShapedType,
     StringAttr,
     SymbolTable,
     Type as IrType,
@@ -39,6 +45,9 @@ from iree.compiler.passmanager import (
 )
 
 from iree.compiler.dialects import (
+    flow as flow_d,
     func as func_d,
     util as util_d,
+    arith as arith_d,
+    tensor as tensor_d,
 )

--- a/python/shark_turbine/aot/support/ir_utils.py
+++ b/python/shark_turbine/aot/support/ir_utils.py
@@ -185,6 +185,31 @@ class ModuleBuilder:
             actual_symbol_name = StringAttr(global_op.attributes["sym_name"]).value
             return actual_symbol_name, global_op, tensor_type
 
+    def create_typed_global(
+        self,
+        symbol_name: str,
+        global_type: IrType,
+        *,
+        mutable: bool = False,
+        initialize: bool = True,
+        noinline: bool = True,
+    ) -> Tuple[str, Operation]:
+        with self.global_ip, Location.unknown():
+            attrs = {
+                "sym_name": StringAttr.get(symbol_name),
+                "sym_visibility": StringAttr.get("private"),
+                "type": TypeAttr.get(global_type),
+            }
+            if noinline:
+                attrs["noinline"] = UnitAttr.get()
+            if mutable:
+                attrs["is_mutable"] = UnitAttr.get()
+
+            global_op = Operation.create("util.global", attributes=attrs)
+            self.symbol_table.insert(global_op)
+            actual_symbol_name = StringAttr(global_op.attributes["sym_name"]).value
+            return actual_symbol_name, global_op
+
 
 class FunctionBuilder:
     """Helpers for building function bodies."""

--- a/python/shark_turbine/aot/support/ir_utils.py
+++ b/python/shark_turbine/aot/support/ir_utils.py
@@ -265,8 +265,7 @@ def build_index_attribute(value: int) -> IntegerAttr:
 
 
 def build_index_value(value: int) -> Value:
-    attr = build_index_attribute(value)
-    return arith_d.ConstantOp(attr.type, attr).result
+    return arith_d.ConstantOp(IndexType.get(), value).result
 
 
 def build_tensor_dim_value(t: Value, dim: int) -> Value:

--- a/python/shark_turbine/aot/support/ir_utils.py
+++ b/python/shark_turbine/aot/support/ir_utils.py
@@ -16,6 +16,8 @@ from ...dynamo.importer import (
 )
 
 from .ir_imports import (
+    Block,
+    BlockArgument,
     BF16Type,
     ComplexType,
     DenseElementsAttr,
@@ -23,10 +25,13 @@ from .ir_imports import (
     F32Type,
     F64Type,
     FunctionType,
+    IndexType,
     InsertionPoint,
+    IntegerAttr,
     IntegerType,
     IrType,
     Location,
+    OpResult,
     Operation,
     RankedTensorType,
     StringAttr,
@@ -34,7 +39,9 @@ from .ir_imports import (
     TypeAttr,
     UnitAttr,
     Value,
+    arith_d,
     func_d,
+    tensor_d,
 )
 
 from .utils import (
@@ -221,3 +228,21 @@ class FunctionBuilder:
             ftype = FunctionType.get(ftype.inputs, value_types)
             self.func_op.attributes["function_type"] = TypeAttr.get(ftype)
             assert self.func_op.verify(), "Created function is invalid"
+
+
+###############################################################################
+# Helpers
+###############################################################################
+
+
+def build_index_attribute(value: int) -> IntegerAttr:
+    return IntegerAttr.get(IndexType.get(), value)
+
+
+def build_index_value(value: int) -> Value:
+    attr = build_index_attribute(value)
+    return arith_d.ConstantOp(attr.type, attr).result
+
+
+def build_tensor_dim_value(t: Value, dim: int) -> Value:
+    return tensor_d.DimOp(t, build_index_value(dim)).result

--- a/python/shark_turbine/aot/support/utils.py
+++ b/python/shark_turbine/aot/support/utils.py
@@ -32,7 +32,11 @@ thread_state = threading.local()
 
 # Opaque value to indicate something is empty. Used in cases where 'None'
 # may have a different meaning.
-Empty = object()
+class EmptyType:
+    ...
+
+
+Empty = EmptyType()
 
 
 class RefMapping:

--- a/tests/aot/iree_procedural_test.py
+++ b/tests/aot/iree_procedural_test.py
@@ -1,0 +1,77 @@
+# Copyright 2023 Nod Labs, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+import unittest
+
+import torch
+
+from iree.compiler.ir import (
+    Context,
+)
+
+from shark_turbine.aot import *
+
+
+class CompiledModuleAPI(unittest.TestCase):
+    def testTensorDim(self):
+        class BasicModule(CompiledModule):
+            def foobar(self, a=AbstractTensor(None, 3)):
+                return IREE.tensor_dim(a, 0)
+
+        inst = BasicModule(context=Context())
+        module_str = str(CompiledModule.get_mlir_module(inst))
+        print(module_str)
+        self.assertIn("%c0 = arith.constant 0", module_str)
+        self.assertIn("%dim = tensor.dim %arg0, %c0", module_str)
+        self.assertIn("return %dim", module_str)
+
+    def testTensorEmpty(self):
+        class BasicModule(CompiledModule):
+            def foobar(self, x=AbstractIndex):
+                empty = IREE.tensor_empty(x, 16)
+                dim0 = IREE.tensor_dim(empty, 0)
+                return empty, dim0
+
+        inst = BasicModule(context=Context())
+        module_str = str(CompiledModule.get_mlir_module(inst))
+        print(module_str)
+        self.assertIn("%0 = flow.tensor.empty : tensor<?x16xf32>{%arg0}", module_str)
+        # NOTE: We are testing below that the dynamic dimension is associated
+        # and used from the input vs being recalculated.
+        self.assertIn("return %0, %arg0 : tensor<?x16xf32>, index", module_str)
+
+    def testTensorSplat(self):
+        class BasicModule(CompiledModule):
+            def foobar(self, x=AbstractIndex, y=AbstractF32):
+                empty = IREE.tensor_splat(x, 34, value=y, dtype=torch.float32)
+                dim0 = IREE.tensor_dim(empty, 0)
+                return empty, dim0
+
+        inst = BasicModule(context=Context())
+        module_str = str(CompiledModule.get_mlir_module(inst))
+        print(module_str)
+        self.assertIn(
+            "%0 = flow.tensor.splat %arg1 : tensor<?x34xf32>{%arg0}", module_str
+        )
+        # NOTE: We are testing below that the dynamic dimension is associated
+        # and used from the input vs being recalculated.
+        self.assertIn("return %0, %arg0 : tensor<?x34xf32>, index", module_str)
+
+    def testTensorTrace(self):
+        class BasicModule(CompiledModule):
+            def foobar(self, x=AbstractTensor(None), y=AbstractTensor(3)):
+                IREE.tensor_trace("DEBUG", x, y)
+
+        inst = BasicModule(context=Context())
+        module_str = str(CompiledModule.get_mlir_module(inst))
+        print(module_str)
+        self.assertIn('flow.tensor.trace {key = "DEBUG"} %arg0, %arg1', module_str)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()


### PR DESCRIPTION
* Boilerplate and type support for procedural emission of IREE specific IR constructs.
* Dynamic shape aware `tensor_dim`, `tensor_empty`, `tensor_splat` builders.
* Added `tensor_trace` since it was there and easy.
* Unlike upstream MLIR, this layer respects IREE's ranked/op-carried symbolic shapes and does the frontend accounting to make sure that dynamic dims thread through explicitly.
* I was really aiming at the slice ops but started simple. Will get to those next.
* Eventually, this will grow to support all procedural IR that IREE supports (loops, conditionals, streamable calls, etc). And at a future point, I will sugar it appropriately.