### PR TITLE
Added decomposition ops for MNIST test debugging

### DIFF
--- a/python/shark_turbine/dynamo/passes.py
+++ b/python/shark_turbine/dynamo/passes.py
@@ -42,6 +42,9 @@ CPU_DECOMPOSITIONS = [
     torch.ops.aten._adaptive_avg_pool2d,
     torch.ops.aten._prelu_kernel,
     torch.ops.aten.full,
+    torch.ops.aten._log_softmax,
+    torch.ops.aten.nll_loss_forward,
+    torch.ops.aten._to_copy,
 ]
 
 


### PR DESCRIPTION
Added to cpu_decomposition`aten._log_softmax`, `aten.nll_loss_forward`, `aten._to_copy`,
Decomposition of `aten.scalar_tensor` op at torch-mlir has also landed. (https://github.com/llvm/torch-mlir/pull/2481).


