### PR TITLE
Implement import phasing in AOT to avoid incremental compilation of j…

### DIFF
--- a/python/shark_turbine/aot/builtins/jittable.py
+++ b/python/shark_turbine/aot/builtins/jittable.py
@@ -188,25 +188,6 @@ class jittable(CallableIntrinsic):
         # TODO: Real debugging options
         # print(fx_importer.module, file=sys.stderr)
 
-        # Within the isolated module, convert to MLIR.
-        # with proc_trace.context as context:
-        #     try:
-        #         pm = PassManager.parse("builtin.module(torch-to-iree)")
-        #         # Uncomment these two lines to debug.
-        #         # TODO: Real debug options.
-        #         # context.enable_multithreading(False)
-        #         # pm.enable_ir_printing()
-        #         # Run.
-        #         pm.run(fx_importer.module.operation)
-        #     except MLIRError:
-        #         # TODO: Better error handling.
-        #         print(fx_importer.module.operation, file=sys.stderr)
-        #         raise
-
-        # Uncomment to print the final module.
-        # TODO: Real debugging options.
-        # print(fx_importer.module.operation, file=sys.stderr)
-
         # Splice the converted module into the main module by taking advantage
         # of what we know about the conversion module:
         #   1. There will be a public function of `self.function_name` that we

--- a/python/shark_turbine/aot/support/ir_utils.py
+++ b/python/shark_turbine/aot/support/ir_utils.py
@@ -15,6 +15,10 @@ from ...dynamo.importer import (
     TORCH_DTYPE_TO_MLIR_TYPE_ASM,
 )
 
+from ...dynamo.type_conversion import (
+    NativeTypeConverter,
+)
+
 from .ir_imports import (
     Block,
     BlockArgument,
@@ -109,6 +113,7 @@ class ModuleBuilder:
         "module_op",
         "symbol_table",
         "global_ref_tracker",
+        "native_type_converter",
     ]
 
     def __init__(self, module_op: Operation):
@@ -121,6 +126,7 @@ class ModuleBuilder:
         self.cache = ContextCache(self.context)
         # Tracks global references to a MaterializedGlobal.
         self.global_ref_tracker = RefTracker()
+        self.native_type_converter = NativeTypeConverter(self.context)
 
     def finalize_construct(self):
         self.module_op.verify()

--- a/python/shark_turbine/dynamo/type_conversion.py
+++ b/python/shark_turbine/dynamo/type_conversion.py
@@ -1,0 +1,161 @@
+# Copyright 2023 Nod Labs, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Converters to/from torch types.
+
+Note that there are ad-hoc type conversions spread around a bit, and we
+should consolidate them here.
+"""
+from typing import List
+
+import functools
+import re
+
+from iree.compiler.ir import (
+    Context,
+    F64Type,
+    IntegerType,
+    RankedTensorType,
+    ShapedType,
+    Type as IrType,
+    Location,
+    Operation,
+    Value,
+)
+
+# Match an overall torch type declaration. Groups:
+#   1. Local name (int, float, vtensor)
+#   2. Parameter block ("<...>"), including the delimitters
+#   3. Inner parameter block (no delimitters)
+DECOMPOSE_TORCH_TYPE_PATTERN = re.compile(r"^!torch.([^<]+)(<([^>]*)>)?$")
+
+# Decomposes a vtensor parameter block into a dimension list and dtype. Groups:
+#   1. Dimension list
+#   2. Dtype
+DECOMPOSE_TENSOR_PARAMS_PATTERN = re.compile(r"\[([^\]]*)\],([^,]+)$")
+
+
+class NativeTypeConverter:
+    def __init__(self, context: Context):
+        self._context = context
+        # Cache per instance.
+        self.torch_type_to_native = functools.lru_cache(maxsize=None)(
+            self.torch_type_to_native
+        )
+
+    def torch_type_to_native(self, torch_type: IrType) -> IrType:
+        """Converts a presumed torch type to a corresponding native type.
+
+        This mirrors the type conversion in torch-mlir's BackendTypeConversion.cpp.
+
+        As an example:
+          !torch.int -> i64
+          !torch.float -> f64
+          !torch.bool -> i1
+          !torch.vtensor -> tensor
+        """
+        # We don't presently have API support for introspecting torch type,
+        # and even if we did, it is likely that this is more efficient.
+        m = re.match(DECOMPOSE_TORCH_TYPE_PATTERN, str(torch_type))
+        if m:
+            name, _, params_str = m.groups()
+            with self._context:
+                if name == "bool":
+                    return IntegerType.get_signless(1)
+                if name == "int":
+                    return IntegerType.get_signless(64)
+                elif name == "float":
+                    return F64Type.get()
+                elif name == "vtensor":
+                    tm = re.match(DECOMPOSE_TENSOR_PARAMS_PATTERN, params_str)
+                    assert tm, f"Could not parse !torch.vtensor params: {params_str}"
+                    dim_list_str, dtype_str = tm.groups()
+                    dim_list = parse_tensor_dim_list(dim_list_str)
+                    dtype = IrType.parse(dtype_str)
+                    # TODO: Eliminate RankedTensorType dependence on Location.
+                    with Location.unknown():
+                        return RankedTensorType.get(dim_list, dtype)
+        raise TypeError(f"Unsupported torch type conversion for {torch_type}")
+
+    def materialize_native_to_torch(
+        self, native_value: Value, torch_type: IrType
+    ) -> Value:
+        native_type = native_value.type
+        if RankedTensorType.isinstance(native_type):
+            # Convert to vtensor.
+            return Operation.create(
+                "torch_c.from_builtin_tensor",
+                results=[torch_type],
+                operands=[native_value],
+            ).result
+        elif IntegerType.isinstance(native_type):
+            # Convert to !torch.int
+            int_type = IntegerType(native_type)
+            width = int_type.width
+            if width == 1:
+                op_name = "torch_c.from_i1"
+            elif width == 64:
+                op_name = "torch_c.from_i64"
+            else:
+                raise TypeError(
+                    f"Unsupported integer bit width for native->torch ABI: {int_type}"
+                )
+            return Operation.create(
+                op_name, results=[torch_type], operands=[native_value]
+            ).result
+        elif F64Type.isinstance(native_type):
+            # Convert to !torch.float
+            return Operation.create(
+                "torch_c.from_f64", results=[torch_type], operands=[native_type]
+            ).result
+        else:
+            raise TypeError(
+                f"Unsupported native->torch ABI type conversion: {native_type} -> {torch_type}"
+            )
+
+    def materialize_torch_to_native(self, torch_value: Value) -> Value:
+        native_type = self.torch_type_to_native(torch_value.type)
+        if RankedTensorType.isinstance(native_type):
+            # Convert to vtensor.
+            return Operation.create(
+                "torch_c.to_builtin_tensor",
+                results=[native_type],
+                operands=[torch_value],
+            ).result
+        elif IntegerType.isinstance(native_type):
+            # Convert to !torch.int
+            int_type = IntegerType(native_type)
+            width = int_type.width
+            if width == 1:
+                op_name = "torch_c.to_i1"
+            elif width == 64:
+                op_name = "torch_c.to_i64"
+            else:
+                raise TypeError(
+                    f"Unsupported integer bit width for torch->native ABI: {int_type}"
+                )
+            return Operation.create(
+                op_name, results=[native_type], operands=[torch_value]
+            ).result
+        elif F64Type.isinstance(native_type):
+            # Convert to !torch.float
+            return Operation.create(
+                "torch_c.to_f64", results=[native_type], operands=[torch_value]
+            ).result
+        else:
+            raise TypeError(
+                f"Unsupported torch->native ABI type conversion: {native_type} -> {native_type}"
+            )
+
+
+ShapedTypeDynamicSizeSentinel = ShapedType.get_dynamic_size()
+
+
+def parse_tensor_dim_list(dim_list_str: str) -> List[int]:
+    if not dim_list_str:
+        return []
+    comps = dim_list_str.split(",")
+    return [ShapedTypeDynamicSizeSentinel if d == "?" else int(d) for d in comps]

--- a/tests/aot/api_test.py
+++ b/tests/aot/api_test.py
@@ -70,27 +70,6 @@ class CompiledModuleAPI(unittest.TestCase):
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
 
-    def testExportedNoArgJit(self):
-        class ExportedProcModule(CompiledModule):
-            def foobar(self):
-                return self.compute(), self.compute()
-
-            @CompiledModule.jittable
-            def compute():
-                t1 = torch.ones(2, 2)
-                t2 = t1 + t1
-                return t2 * t2
-
-        inst = ExportedProcModule(context=Context())
-        module_str = str(CompiledModule.get_mlir_module(inst))
-        print(module_str)
-        # Assert that the compute function was imported twice and called.
-        # TODO: Implement jit function caching to avoid doing this on
-        # equivalent signatures.
-        self.assertIn("%0 = call @compute()", module_str)
-        self.assertIn("%1 = call @compute$1()", module_str)
-        self.assertIn("return %0, %1 : tensor<2x2xf32>, tensor<2x2xf32>", module_str)
-
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)

--- a/tests/aot/globals_test.py
+++ b/tests/aot/globals_test.py
@@ -200,7 +200,7 @@ class ArgsTest(unittest.TestCase):
             state0 = export_global(state_example, mutable=True, initialize=False)
 
             def tensor_update_state(self, update=abstractify(update_example)):
-                IREE.tensor_update(self.state0, update, 0, 0)
+                return IREE.tensor_update(self.state0, update, 0, 0)
 
         inst = SingleState(context=Context())
         module_str = str(CompiledModule.get_mlir_module(inst))

--- a/tests/aot/iree_procedural_test.py
+++ b/tests/aot/iree_procedural_test.py
@@ -22,7 +22,7 @@ class CompiledModuleAPI(unittest.TestCase):
             def foobar(self, a=AbstractTensor(None, 3)):
                 return IREE.tensor_dim(a, 0)
 
-        inst = BasicModule(context=Context())
+        inst = BasicModule(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn("%c0 = arith.constant 0", module_str)
@@ -36,7 +36,7 @@ class CompiledModuleAPI(unittest.TestCase):
                 dim0 = IREE.tensor_dim(empty, 0)
                 return empty, dim0
 
-        inst = BasicModule(context=Context())
+        inst = BasicModule(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn("%0 = flow.tensor.empty : tensor<?x16xf32>{%arg0}", module_str)
@@ -51,7 +51,7 @@ class CompiledModuleAPI(unittest.TestCase):
                 dim0 = IREE.tensor_dim(empty, 0)
                 return empty, dim0
 
-        inst = BasicModule(context=Context())
+        inst = BasicModule(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
@@ -66,7 +66,7 @@ class CompiledModuleAPI(unittest.TestCase):
             def foobar(self, x=AbstractTensor(None), y=AbstractTensor(3)):
                 IREE.tensor_trace("DEBUG", x, y)
 
-        inst = BasicModule(context=Context())
+        inst = BasicModule(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn('flow.tensor.trace {key = "DEBUG"} %arg0, %arg1', module_str)
@@ -79,7 +79,7 @@ class CompiledModuleAPI(unittest.TestCase):
                 splat = IREE.tensor_splat(x, 34, value=y, dtype=torch.float32)
                 self.x = splat
 
-        inst = BasicModule(context=Context())
+        inst = BasicModule(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
@@ -94,7 +94,7 @@ class CompiledModuleAPI(unittest.TestCase):
             def foobar(self, x=AbstractTensor(3, 4)):
                 return IREE.tensor_slice(x, 0, (1, 3))
 
-        inst = BasicModule(context=Context())
+        inst = BasicModule(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
@@ -108,7 +108,7 @@ class CompiledModuleAPI(unittest.TestCase):
                 empty = IREE.tensor_empty(x, 16)
                 return IREE.tensor_slice(empty, x, 4)
 
-        inst = SliceDynamicIndex(context=Context())
+        inst = SliceDynamicIndex(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
@@ -122,7 +122,7 @@ class CompiledModuleAPI(unittest.TestCase):
                 empty = IREE.tensor_empty(x, 16)
                 return IREE.tensor_slice(empty, (x, y), 4)
 
-        inst = SliceDynamicIndex(context=Context())
+        inst = SliceDynamicIndex(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
@@ -141,7 +141,7 @@ class CompiledModuleAPI(unittest.TestCase):
             ):
                 return IREE.tensor_update(target, update, i, j)
 
-        inst = UpdateStatic(context=Context())
+        inst = UpdateStatic(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
@@ -163,7 +163,7 @@ class CompiledModuleAPI(unittest.TestCase):
                 update = IREE.tensor_splat(i, j, value=value, dtype=torch.float32)
                 return IREE.tensor_update(target, update, 2, 2)
 
-        inst = UpdateDynamic(context=Context())
+        inst = UpdateDynamic(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
@@ -178,7 +178,7 @@ class CompiledModuleAPI(unittest.TestCase):
                 reshaped = IREE.tensor_reshape(empty, 1, y, y)
                 return reshaped
 
-        inst = ReshapeModule(context=Context())
+        inst = ReshapeModule(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
@@ -191,7 +191,7 @@ class CompiledModuleAPI(unittest.TestCase):
             def foobar(self, a=AbstractI32, b=AbstractI32):
                 return a + b
 
-        inst = ArithModule(context=Context())
+        inst = ArithModule(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         self.assertIn("arith.addi %arg0, %arg1 : i32", module_str)
 
@@ -200,7 +200,7 @@ class CompiledModuleAPI(unittest.TestCase):
             def foobar(self, a=AbstractF32, b=AbstractF32):
                 return a + b
 
-        inst = ArithModule(context=Context())
+        inst = ArithModule(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         self.assertIn("arith.addf %arg0, %arg1 : f32", module_str)
 
@@ -209,7 +209,7 @@ class CompiledModuleAPI(unittest.TestCase):
             def foobar(self, a=AbstractI32):
                 return a + 1
 
-        inst = ArithModule(context=Context())
+        inst = ArithModule(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         self.assertIn("%c1_i32 = arith.constant 1 : i32", module_str)
         self.assertIn("arith.addi %arg0, %c1_i32 : i32", module_str)
@@ -219,7 +219,7 @@ class CompiledModuleAPI(unittest.TestCase):
             def foobar(self, a=AbstractI32):
                 return a + 3.23
 
-        inst = ArithModule(context=Context())
+        inst = ArithModule(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         self.assertIn("%0 = arith.sitofp %arg0 : i32 to f32", module_str)
         self.assertIn("%cst = arith.constant 3.230000e+00 : f32", module_str)

--- a/tests/aot/jittable_test.py
+++ b/tests/aot/jittable_test.py
@@ -1,0 +1,46 @@
+# Copyright 2023 Nod Labs, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+import unittest
+
+import torch
+
+from iree.compiler.ir import (
+    Context,
+)
+
+from shark_turbine.aot import *
+
+
+class JittableTests(unittest.TestCase):
+    def testImportPhases(self):
+        class ExportedProcModule(CompiledModule):
+            def foobar(self):
+                return self.compute(), self.compute()
+
+            @CompiledModule.jittable
+            def compute():
+                t1 = torch.ones(2, 2)
+                t2 = t1 + t1
+                return t2 * t2
+
+        inst = ExportedProcModule(context=Context(), import_to="import")
+        module_str = str(CompiledModule.get_mlir_module(inst))
+        print(module_str)
+        # Functions should still be on torch types.
+        self.assertIn(
+            "func private @compute() -> !torch.vtensor<[2,2],f32>", module_str
+        )
+        CompiledModule.run_import(inst)
+        module_str = str(CompiledModule.get_mlir_module(inst))
+        print(module_str)
+        self.assertNotIn("!torch.vtensor", module_str)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/tests/dynamo/type_conversion_test.py
+++ b/tests/dynamo/type_conversion_test.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Nod Labs, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+import unittest
+
+from iree.compiler.ir import (
+    Context,
+    Type as IrType,
+)
+
+import shark_turbine.dynamo.type_conversion as tc
+
+
+class TypeConversionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.conv = tc.NativeTypeConverter(Context())
+
+    def testPrimitives(self):
+        self._compareNative("!torch.bool", "i1")
+        self._compareNative("!torch.int", "i64")
+        self._compareNative("!torch.float", "f64")
+
+    def testValueTensors(self):
+        self._compareNative("!torch.vtensor<[2, 2],f32>", "tensor<2x2xf32>")
+        self._compareNative("!torch.vtensor<[?, ?],f32>", "tensor<?x?xf32>")
+        self._compareNative("!torch.vtensor<[],f32>", "tensor<f32>")
+
+    def _compareNative(self, torch_str: str, native_str: str):
+        with self.conv._context:
+            torch_type = IrType.parse(torch_str)
+        native_type = self.conv.torch_type_to_native(torch_type)
+        self.assertEqual(str(native_type), native_str)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()


### PR DESCRIPTION
…ittables.

Primarily, this reworks jittable so that it always does a pure import into the torch dialect, not lowering each compute function to linalg incrementally. The result is that we have a module at the torch level which is legal input to IREE's `torch-to-iree` input pipeline (vs the result of that). In addition to likely being more resilient to change (since we control the dialects), it should also be more debuggable since it is easy now to dump to a file and continue with CL tools before any real compilation has taken place.

In order to make this work, we add an `import_to=` kwarg to the CompileModule that allows disabling any import-based compilation. Also adds a couple of other APIs for ergonomics:

* `run_import`
* `run_pass_pipeline`
* `save_mlir`

By default, we run the full import pipeline as part of constructing the module. We may change this in the future.