### PR TITLE
Fix mnist test dataloader

### DIFF
--- a/examples/eager_mlp/mlp_eager_simple.py
+++ b/examples/eager_mlp/mlp_eager_simple.py
@@ -39,7 +39,7 @@ class MNISTDataLoader:
 
     def get_test_loader(self):
         return DataLoader(
-            dataset=self.mnist_testset, batch_size=self.batch_size, shuffle=False
+            dataset=self.mnist_testset, batch_size=self.batch_size, shuffle=False, drop_last=True,
         )
 
 
@@ -70,7 +70,7 @@ def infer_iteration(model, images):
 def infer():
     # Example Parameters
     config = {
-        "batch_size": 100,
+        "batch_size": 64,
         "learning_rate": 0.001,
         "num_epochs": 10,
     }

--- a/tests/dynamo/mninst_test.py
+++ b/tests/dynamo/mninst_test.py
@@ -44,7 +44,7 @@ class MNISTDataLoader:
 
     def get_test_loader(self):
         return DataLoader(
-            dataset=self.mnist_testset, batch_size=self.batch_size, shuffle=False
+            dataset=self.mnist_testset, batch_size=self.batch_size, shuffle=False, drop_last=True,
         )
 
 
@@ -75,7 +75,7 @@ def infer_iteration(model, images):
 def infer():
     # Example Parameters
     config = {
-        "batch_size": 100,
+        "batch_size": 64,
         "learning_rate": 0.001,
         "num_epochs": 10,
     }


### PR DESCRIPTION
Another way to address the issue https://github.com/nod-ai/SHARK-Turbine/issues/93, where not all inputs are tensors depending on batchsize during execution. We simply set `drop_last=True` in the data loader. 