### PR TITLE
[llama] transpose global state

### DIFF
--- a/examples/aot_mlp/mlp_export_simple.py
+++ b/examples/aot_mlp/mlp_export_simple.py
@@ -34,6 +34,7 @@ class MLP(nn.Module):
 model = MLP()
 example_x = torch.empty(97, 8, dtype=torch.float32)
 exported = aot.export(model, example_x)
+aot.CompiledModule.run_import(exported.compiled_module)
 exported.print_readable()
 compiled_binary = exported.compile(save_to=None)
 


### PR DESCRIPTION
Transposed the global state to allow continuous memory access while updating. Previously only the 0th idx of the 2nd dim was getting updated on initialization. Also update needs to be stored back to the global variable. Couple other minor bugfixes.