### PR TITLE
Adds support for IREE external parameters at module export time.

### DIFF
--- a/python/shark_turbine/aot/support/ir_imports.py
+++ b/python/shark_turbine/aot/support/ir_imports.py
@@ -8,6 +8,7 @@
 """Unifies all imports of iree.compiler.ir into one place."""
 
 from iree.compiler.ir import (
+    Attribute,
     Block,
     BlockArgument,
     Context,

--- a/python/shark_turbine/aot/support/ir_utils.py
+++ b/python/shark_turbine/aot/support/ir_utils.py
@@ -23,6 +23,7 @@ from ...dynamo.type_conversion import (
 )
 
 from .ir_imports import (
+    Attribute,
     Block,
     BlockArgument,
     BF16Type,
@@ -100,6 +101,57 @@ TORCH_DTYPE_TO_IREE_TYPE_ASM = {
     torch.complex64: "complex<f32>",
     torch.complex128: "complex<f64>",
 }
+
+###############################################################################
+# Configuration
+###############################################################################
+
+# Maps a name to an altered name. If returns None, then the original
+# name is used (this lets Dict.get serve as a NameMapCallback).
+NameMapCallback = Callable[[str], Optional[str]]
+
+
+class GlobalAttributes:
+    """Settings for how to initialize the global."""
+
+    __slots__ = [
+        "mutable",
+        "initialize",
+        "external",
+        "external_scope",
+        "name_mapper",
+        "noinline",
+    ]
+
+    def __init__(
+        self,
+        mutable: bool = False,
+        initialize: Optional[bool] = None,
+        external: Optional[bool] = None,
+        external_scope: Optional[str] = None,
+        name_mapper: Optional[NameMapCallback] = None,
+        noinline: bool = True,
+    ):
+        if initialize and external:
+            raise ValueError("Only one of initialize=True or external=True is allowed")
+        if initialize is None and external is None:
+            # Initialize by default.
+            initialize = True
+
+        self.mutable = mutable
+        self.initialize = initialize
+        self.external = external
+        self.external_scope = external_scope
+        self.name_mapper = name_mapper
+        self.noinline = noinline
+
+    def map_name(self, name: str) -> str:
+        if self.name_mapper:
+            new_name = self.name_mapper(name)
+            if new_name is not None:
+                return new_name
+        return name
+
 
 ###############################################################################
 # Builders
@@ -187,23 +239,22 @@ class ModuleBuilder:
         symbol_name: str,
         t: torch.Tensor,
         *,
-        mutable: bool = False,
-        initialize: bool = True,
-        noinline: bool = True,
+        attrs: GlobalAttributes,
+        logical_name: Optional[str] = None,
     ) -> Tuple[str, Operation, IrType]:
         element_type = self.torch_dtype_to_iree_type(t.dtype)
         with self.global_ip, Location.unknown():
             tensor_type = RankedTensorType.get(list(t.shape), element_type)
-            attrs = {
+            ir_attrs = {
                 "sym_name": StringAttr.get(symbol_name),
                 "sym_visibility": StringAttr.get("private"),
                 "type": TypeAttr.get(tensor_type),
             }
-            if noinline:
-                attrs["noinline"] = UnitAttr.get()
-            if mutable:
-                attrs["is_mutable"] = UnitAttr.get()
-            if initialize:
+            if attrs.noinline:
+                ir_attrs["noinline"] = UnitAttr.get()
+            if attrs.mutable:
+                ir_attrs["is_mutable"] = UnitAttr.get()
+            if attrs.initialize:
                 detached_tensor = t.detach().contiguous().cpu()
                 array = np.array(detached_tensor)
                 # We know that a Numpy array is a ReadableBuffer so ignore type error.
@@ -211,9 +262,19 @@ class ModuleBuilder:
                 # TODO: Add resource elements to Python API and use that.
                 # See: https://github.com/nod-ai/SHARK-Turbine/issues/137
                 elements_attr = DenseElementsAttr.get(contents, type=tensor_type)
-                attrs["initial_value"] = elements_attr
+                ir_attrs["initial_value"] = elements_attr
+            elif attrs.external:
+                external_scope_attr = StringAttr.get(attrs.external_scope or "model")
+                external_name = attrs.map_name(
+                    logical_name if logical_name is not None else symbol_name
+                )
+                external_name_attr = StringAttr.get(external_name)
+                # TODO: Have real Python builders for this.
+                ir_attrs["initial_value"] = Attribute.parse(
+                    f"#stream.parameter.named<{external_scope_attr}::{external_name_attr}> : {tensor_type}"
+                )
 
-            global_op = Operation.create("util.global", attributes=attrs)
+            global_op = Operation.create("util.global", attributes=ir_attrs)
             self.symbol_table.insert(global_op)
             actual_symbol_name = StringAttr(global_op.attributes["sym_name"]).value
             return actual_symbol_name, global_op, tensor_type
@@ -223,22 +284,21 @@ class ModuleBuilder:
         symbol_name: str,
         global_type: IrType,
         *,
-        mutable: bool = False,
-        initialize: bool = True,
-        noinline: bool = True,
+        attrs: GlobalAttributes,
+        logical_name: Optional[str] = None,
     ) -> Tuple[str, Operation]:
         with self.global_ip, Location.unknown():
-            attrs = {
+            ir_attrs = {
                 "sym_name": StringAttr.get(symbol_name),
                 "sym_visibility": StringAttr.get("private"),
                 "type": TypeAttr.get(global_type),
             }
-            if noinline:
-                attrs["noinline"] = UnitAttr.get()
-            if mutable:
-                attrs["is_mutable"] = UnitAttr.get()
+            if attrs.noinline:
+                ir_attrs["noinline"] = UnitAttr.get()
+            if attrs.mutable:
+                ir_attrs["is_mutable"] = UnitAttr.get()
 
-            global_op = Operation.create("util.global", attributes=attrs)
+            global_op = Operation.create("util.global", attributes=ir_attrs)
             self.symbol_table.insert(global_op)
             actual_symbol_name = StringAttr(global_op.attributes["sym_name"]).value
             return actual_symbol_name, global_op

--- a/python/shark_turbine/aot/support/procedural/globals.py
+++ b/python/shark_turbine/aot/support/procedural/globals.py
@@ -9,8 +9,10 @@
 
 from typing import (
     Any,
+    Callable,
     Dict,
     Generator,
+    Optional,
     Sequence,
     Tuple,
 )
@@ -25,6 +27,7 @@ from ..ir_imports import (
 )
 
 from ..ir_utils import (
+    GlobalAttributes,
     ModuleBuilder,
 )
 
@@ -87,13 +90,11 @@ class GlobalsDef:
     """Base class for all exporting descriptors."""
 
     __slots__ = [
-        "_initialize",
-        "_mutable",
+        "_attrs",
     ]
 
-    def __init__(self, *, initialize: bool, mutable: bool):
-        self._initialize = initialize
-        self._mutable = mutable
+    def __init__(self, attrs: GlobalAttributes):
+        self._attrs = attrs
 
     def items(self) -> Generator[Tuple[str, Any], None, None]:
         """Yields tuples of name/value exports."""
@@ -124,8 +125,8 @@ class GlobalsDef:
                 ) = module_builder.create_tensor_global(
                     f"_{fq_name}",
                     value,
-                    initialize=self._initialize,
-                    mutable=self._mutable,
+                    attrs=self._attrs,
+                    logical_name=fq_name,
                 )
                 mapping.value = IrGlobalTensor(
                     fq_name,
@@ -140,11 +141,14 @@ class GlobalsDef:
                 continue
             elif isinstance(value, AbstractTensor):
                 global_type = value.get_ir_type(module_builder)
-                (actual_symbol_name, global_op,) = module_builder.create_typed_global(
+                (
+                    actual_symbol_name,
+                    global_op,
+                ) = module_builder.create_typed_global(
                     f"_{fq_name}",
                     global_type,
-                    initialize=self._initialize,
-                    mutable=self._mutable,
+                    attrs=self._attrs,
+                    logical_name=fq_name,
                 )
                 flat_globals.append(
                     IrGlobalTensor(
@@ -159,11 +163,14 @@ class GlobalsDef:
                 continue
             elif isinstance(value, AbstractScalar):
                 global_type = value.get_ir_type(module_builder)
-                (actual_symbol_name, global_op,) = module_builder.create_typed_global(
+                (
+                    actual_symbol_name,
+                    global_op,
+                ) = module_builder.create_typed_global(
                     f"_{fq_name}",
                     global_type,
-                    initialize=self._initialize,
-                    mutable=self._mutable,
+                    attrs=self._attrs,
+                    logical_name=fq_name,
                 )
                 flat_globals.append(
                     IrGlobalScalar(

--- a/python/shark_turbine/aot/support/utils.py
+++ b/python/shark_turbine/aot/support/utils.py
@@ -30,6 +30,7 @@ thread_state = threading.local()
 # Reference mapping
 ###############################################################################
 
+
 # Opaque value to indicate something is empty. Used in cases where 'None'
 # may have a different meaning.
 class EmptyType:

--- a/tests/aot/iree_procedural_test.py
+++ b/tests/aot/iree_procedural_test.py
@@ -69,7 +69,10 @@ class CompiledModuleAPI(unittest.TestCase):
         inst = BasicModule(context=Context(), import_to=None)
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
-        self.assertIn('flow.tensor.trace "DEBUG" = [%arg0 : tensor<?xf32>{%dim}, %arg1 : tensor<3xf32>]', module_str)
+        self.assertIn(
+            'flow.tensor.trace "DEBUG" = [%arg0 : tensor<?xf32>{%dim}, %arg1 : tensor<3xf32>]',
+            module_str,
+        )
 
     def testStoreDynamic(self):
         class BasicModule(CompiledModule):

--- a/tests/aot/jittable_test.py
+++ b/tests/aot/jittable_test.py
@@ -42,9 +42,7 @@ class JittableTests(unittest.TestCase):
 
     def testCallWithStructure(self):
         class ProcArgsModule(CompiledModule):
-            def call_with_dicts(
-                self, a=AbstractTensor(3, 2), b=AbstractTensor(1, 1)
-            ):
+            def call_with_dicts(self, a=AbstractTensor(3, 2), b=AbstractTensor(1, 1)):
                 intermediate = self.compute({"a": a, "b": b})
                 return self.compute(intermediate)
 
@@ -61,9 +59,7 @@ class JittableTests(unittest.TestCase):
 
     def testCallWithArgsKwargs(self):
         class ProcArgsModule(CompiledModule):
-            def call_with_kwargs(
-                self, a=AbstractTensor(3, 2), b=AbstractTensor(1, 1)
-            ):
+            def call_with_kwargs(self, a=AbstractTensor(3, 2), b=AbstractTensor(1, 1)):
                 intermediate = self.compute(**{"a": a, "b": b})
                 return self.compute(**intermediate)
 
@@ -78,9 +74,7 @@ class JittableTests(unittest.TestCase):
 
     def testDynamicDims(self):
         class ProcArgsModule(CompiledModule):
-            def dynamic_dim(
-                self, a=AbstractTensor(None, 2), b=AbstractTensor(None, 1)
-            ):
+            def dynamic_dim(self, a=AbstractTensor(None, 2), b=AbstractTensor(None, 1)):
                 return self.compute(
                     a,
                     b,


### PR DESCRIPTION
* Adds kwargs to builtins that create parameters and globals:
  * external=True : Emit as an external parameter
  * external_scope : Set an explicit external scope
  * name_mapper : Callback to map logical name on the module to parameter name

Requires an IREE nightly bump.