### PR TITLE
[tk] Fill out the type system.

### DIFF
--- a/python/shark_turbine/kernel/_support/typing.py
+++ b/python/shark_turbine/kernel/_support/typing.py
@@ -1,0 +1,2 @@
+from typing import Callable
+import inpsect

--- a/python/shark_turbine/kernel/lang/types.py
+++ b/python/shark_turbine/kernel/lang/types.py
@@ -1,14 +1,167 @@
+from typing import ClassVar, Optional, Type, TypeVar, Union, cast
 import torch
 
 __all__ = [
     "KernelBuffer",
     "Grid",
+    "SymbolDef",
+    "sym",
 ]
 
 Grid = tuple[int, ...]
 
 
-class KernelBuffer:
+###############################################################################
+# Dimension symbols
+###############################################################################
+
+
+class SymbolDef:
+    """Represents a named symbol representing a dimension in a shape."""
+
+    ALL_SYMBOLS: ClassVar[dict[str, "SymbolDef"]] = dict()
+    name: str
+
+    def __new__(cls, name: str):
+        existing = cls.ALL_SYMBOLS.get(name)
+        if existing is not None:
+            return existing
+        new = super().__new__(cls)
+        new.name = name
+        cls.ALL_SYMBOLS[name] = new
+        return new
+
+    def __repr__(self):
+        return f"Symbol({self.name})"
+
+    @classmethod
+    def create_expando(cls):
+        """Create an expando class that creates unique symbols based on attr access."""
+
+        class Expando:
+            def __getattr__(self, n):
+                return cls(n)
+
+        return Expando()
+
+
+sym = SymbolDef.create_expando()
+
+###############################################################################
+# Grid
+###############################################################################
+
+
+class _GridMeta(type):
+    """Meta-class for a symbolically shaped grid."""
+
+    def __new__(
+        mcls,
+        name: str,
+        bases,
+        dct,
+        *,
+        symbolic_shape: Optional[tuple[SymbolDef]],
+    ):
+        new_class = type.__new__(mcls, name, bases, dct)
+        new_class.symbolic_shape = symbolic_shape
+        new_class.rank = len(symbolic_shape) if symbolic_shape is not None else None
+        new_class.__qualname__ = repr(new_class)
+        return new_class
+
+    def __class_getitem__(
+        cls, symbolic_shape: Union[SymbolDef, tuple[SymbolDef]]
+    ) -> Type["Grid"]:
+        if not isinstance(symbolic_shape, tuple):
+            symbolic_shape = (symbolic_shape,)
+        return cast(Grid, _make_shaped_grid(cls, symbolic_shape))
+
+    def __repr__(self):
+        if self.symbolic_shape:
+            return f"Grid[{', '.join(s.name for s in self.symbolic_shape)}]"
+        else:
+            return "Grid"
+
+
+class Grid(metaclass=_GridMeta, symbolic_shape=None):
+    """Grid with bounding symbolic shape information in the type."""
+
+    symbolic_shape: ClassVar[Optional[tuple[SymbolDef]]]
+    rank: int
+
+    def __init__(self, *dims: int):
+        rank = len(dims)
+        if self.symbolic_shape is not None:
+            if rank != len(self.symbolic_shape):
+                raise ValueError(
+                    f"Cannot create {type(self)}({', '.join(str(i) for i in dims)}): mismatched symbolic rank"
+                )
+
+        self.dims = dims
+        # Shadow the type rank with the actual, which makes it concrete
+        # for the generic case.
+        self.rank = rank
+
+    def __repr__(self):
+        return f"{repr(type(self))}({', '.join(str(i) for i in self.dims)})"
+
+    def __getitem__(self, index: int) -> int:
+        return self.dims[index]
+
+    def __len__(self) -> int:
+        return len(self.dims)
+
+    def __iter__(self):
+        return iter(self.dims)
+
+
+def _make_shaped_grid(cls: Type[Grid], symbolic_shape: tuple[SymbolDef]):
+    class ShapedGrid(Grid, symbolic_shape=symbolic_shape):
+        ...
+
+    return ShapedGrid
+
+
+###############################################################################
+# KernelBuffer
+###############################################################################
+
+
+class _KernelBufferMeta(type):
+    """Meta-class for kernel buffers.
+
+    This lets us specialize with symbolic shape information.
+    """
+
+    def __new__(
+        mcls,
+        name: str,
+        bases,
+        dct,
+        *,
+        symbolic_shape: Optional[tuple[SymbolDef]],
+    ):
+        new_class = type.__new__(mcls, name, bases, dct)
+        new_class.symbolic_shape = symbolic_shape
+        new_class.rank = len(symbolic_shape) if symbolic_shape is not None else None
+        new_class.__qualname__ = repr(new_class)
+        return new_class
+
+    def __class_getitem__(
+        cls, symbolic_shape: Union[SymbolDef, tuple[SymbolDef]]
+    ) -> Type["KernelBuffer"]:
+        if not isinstance(symbolic_shape, tuple):
+            symbolic_shape = (symbolic_shape,)
+        return cast(KernelBuffer, _make_shaped_kernel_buffer(cls, symbolic_shape))
+
+    def __repr__(self):
+        if self.symbolic_shape:
+            return f"KernelBuffer[{', '.join(s.name for s in self.symbolic_shape)}]"
+        else:
+            return "KernelBuffer"
+
+
+class KernelBuffer(metaclass=_KernelBufferMeta, symbolic_shape=None):
     """Represents a buffer in global memory.
 
     Top level kernels always operate on global memory via these
@@ -21,19 +174,34 @@ class KernelBuffer:
     is used.
     """
 
-    __slots__ = [
-        "_tensor",
-    ]
+    symbolic_shape: ClassVar[Optional[tuple[SymbolDef]]]
+    rank: int
 
     def __init__(self, tensor: torch.Tensor):
         assert isinstance(tensor, torch.Tensor), f"Expected Tensor but got {tensor}"
+        type_rank = type(self).rank
+        tensor_rank = len(tensor.shape)
+        if type_rank is not None and type_rank != tensor_rank:
+            raise ValueError(
+                f"Cannot create {type(self)}(tensor({tensor.shape})): mismatched symbolic rank"
+            )
         self._tensor = tensor
+        self.rank = tensor_rank
 
     def __repr__(self):
-        return f"KernelBuffer({self._tensor})"
+        return f"{type(self)}({self._tensor})"
 
     def __setitem__(self, key, item):
         self._tensor.__setitem__(key, item)
 
     def __getitem__(self, key):
         return self._tensor.__getitem__(key)
+
+
+def _make_shaped_kernel_buffer(
+    cls: Type[KernelBuffer], symbolic_shape: tuple[SymbolDef]
+):
+    class ShapedKernelBuffer(KernelBuffer, symbolic_shape=symbolic_shape):
+        ...
+
+    return ShapedKernelBuffer

--- a/tests/kernel/simple_kernel_test.py
+++ b/tests/kernel/simple_kernel_test.py
@@ -11,24 +11,24 @@ import torch
 
 import shark_turbine.kernel as tk
 
+M = tk.lang.sym.M
+K = tk.lang.sym.K
+
 
 class Test(unittest.TestCase):
     def testIotaEager(self):
-        @tk.gen.thread
-        def iota_kernel(out: tk.lang.KernelBuffer):
+        @tk.gen.thread(M)
+        def iota_kernel(out: tk.lang.KernelBuffer[M]):
             i = tk.lang.program_id(0)
             out[i] = i
 
-        print("iota_kernel:", iota_kernel)
-        print("iota_kernel[8]:", iota_kernel[8])
-        print("iota_kernel[8, 1]:", iota_kernel[8, 1])
         out = torch.empty(8, dtype=torch.int32)
         iota_kernel[8](out)
         print(out)
 
     def testIotaFx(self):
-        @tk.gen.thread
-        def iota_kernel(out: tk.lang.KernelBuffer):
+        @tk.gen.thread(M)
+        def iota_kernel(out: tk.lang.KernelBuffer[M]):
             i = tk.lang.program_id(0)
             out[i] = i
 
@@ -41,8 +41,10 @@ class Test(unittest.TestCase):
         #     return None
 
     def testSoftmax(self):
-        @tk.gen.thread
-        def softmax_kernel(input: tk.lang.KernelBuffer, output: tk.lang.KernelBuffer):
+        @tk.gen.thread(M)
+        def softmax_kernel(
+            input: tk.lang.KernelBuffer[M, K], output: tk.lang.KernelBuffer[M, K]
+        ):
             row_index = tk.lang.program_id(0)
             input_row = input[row_index, :]
             numerator = torch.exp(input_row - torch.max(input_row))

--- a/tests/kernel/types_test.py
+++ b/tests/kernel/types_test.py
@@ -1,0 +1,66 @@
+import unittest
+
+import torch
+
+from shark_turbine.kernel.lang.types import *
+
+M = sym.M
+N = sym.N
+
+
+class Test(unittest.TestCase):
+    def testGridRepr(self):
+        self.assertEqual("Grid", repr(Grid))
+        self.assertEqual("Grid[M]", repr(Grid[M]))
+        self.assertEqual("Grid[M, N]", repr(Grid[sym.M, sym.N]))
+
+    def testGridAttrs(self):
+        T = Grid[M, N]
+        self.assertIs(T.symbolic_shape[0], M)
+        self.assertIs(T.symbolic_shape[1], N)
+        self.assertEqual(2, T.rank)
+
+    def testGenericGridInstance(self):
+        g = Grid(1, 2, 3)
+        self.assertEqual(3, len(g))
+        self.assertEqual(1, g[0])
+        self.assertEqual([1, 2, 3], list(g))
+        self.assertEqual(3, g.rank)
+
+    def testShapedGridInstance(self):
+        G = Grid[M, N]
+        with self.assertRaisesRegex(ValueError, "mismatched symbolic rank"):
+            g = G(1, 2, 3)
+
+        g = G(2, 3)
+        self.assertEqual(2, len(g))
+        self.assertEqual(2, g[0])
+        self.assertEqual([2, 3], list(g))
+        self.assertEqual(2, g.rank)
+
+    def testKernelBufferRepr(self):
+        self.assertEqual("KernelBuffer", repr(KernelBuffer))
+        self.assertEqual("KernelBuffer[M]", repr(KernelBuffer[sym.M]))
+        self.assertEqual("KernelBuffer[M, N]", repr(KernelBuffer[sym.M, sym.N]))
+
+    def testKernelBufferAttrs(self):
+        T = KernelBuffer[M, N]
+        self.assertIs(T.symbolic_shape[0], M)
+        self.assertIs(T.symbolic_shape[1], N)
+        self.assertEqual(2, T.rank)
+
+    def testKernelBufferGenericInstance(self):
+        kb = KernelBuffer(torch.empty((3, 4)))
+        self.assertEqual(2, kb.rank)
+
+    def testKernelBufferInstance(self):
+        T1 = KernelBuffer[M]
+        with self.assertRaisesRegex(ValueError, "mismatched symbolic rank"):
+            T1(torch.empty((3, 4)))
+        kb = T1(torch.empty((3,)))
+        self.assertEqual(1, kb.rank)
+        self.assertEqual((M,), kb.symbolic_shape)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Implements dependent typing and symbols for KernelBuffer and Grid.
* Makes `tk.gen.thread` take explicit grid symbols.
* Leaves room for adding/inferring sufficient constraints to enable dynamic vectorization.