### PR TITLE
[tk5] Implement slice analysis and sufficient op coverage for a softmax kernel.

### DIFF
--- a/python/shark_turbine/kernel/compiler/analysis.py
+++ b/python/shark_turbine/kernel/compiler/analysis.py
@@ -1,0 +1,225 @@
+from typing import Any, Optional, Type, Union
+
+from .base import CodegenError
+
+from .._support.indexing import (
+    IndexingContext,
+    SymbolDef,
+    SymbolExpr,
+)
+
+
+NormalizedSlice = list[Union[slice, None]]
+
+
+def _norm_slice_spec(rank: int, slice_spec) -> NormalizedSlice:
+    def _norm_single_slice(s):
+        if s is None or s is ...:
+            return s
+        if isinstance(s, slice):
+            # Validate.
+            if s.step == 0:
+                # A zero step is illegal, but we use it to signal an integer index
+                # vs a range.
+                raise IndexError(f"slice with step 0 is illegal (got {s})")
+            return s
+        else:
+            # Promote a raw value to our special 0-step slice.
+            return slice(s, 0, 0)
+
+    if not isinstance(slice_spec, tuple):
+        slice_spec = (slice_spec,)
+    norm_slices = [_norm_single_slice(s) for s in slice_spec]
+
+    # Replace any ellipses with rank-filling None values.
+    none_count = norm_slices.count(None)
+    ellipses_count = norm_slices.count(...)
+    if ellipses_count == 1:
+        # Expand by the original list of slices less any unit dim insertions.
+        # If negative, this does nothing and will be caught later upon
+        # rank validation.
+        expand_index = norm_slices.index(...)
+        del norm_slices[expand_index]
+        expansion_count = (rank + none_count) - len(norm_slices)
+        for _ in range(expansion_count):
+            norm_slices.insert(expand_index, slice(None))
+    elif ellipses_count > 1:
+        raise IndexError(
+            f"Cannot index into a rank expanding referrent with multiple `...` values"
+        )
+    return norm_slices
+
+
+class SliceAnalysis:
+    """Analyses Python slicing notations such that it can be validated and code generated.
+
+    The numpy page has a good description here:
+        https://numpy.org/doc/1.26/user/basics.indexing.html
+
+    This class analyzes:
+      * Basic Indexing
+      * Slicing and Striding
+      * Dimensional Indexing Tools
+
+    Note that `None` is interpreted as `np.newaxis` (which we do not support).
+
+    Each element of a slice specification can be:
+      * An arbitrary Python value representing a single element span
+      * None to indicate a new unit dimension
+      * Ellipses to indicate space filling `slice()`
+      * A `slice` object
+
+    Such a specification is decomposed into a `source_slice` which does not
+    include any rank broadcasting and a `broadcast_slice` which includes
+    any rank expansion. Depending on the operation being code generated,
+    these will be handled differently. All loose Python values will
+    be promoted into a `slice` object.
+
+    Raises:
+      IndexError on any violations of Python indexing semantics which
+      are statically determined during analysis.
+    """
+
+    def __init__(self, ref: tuple[SymbolExpr, ...], slice_spec):
+        self.ref = ref
+        self.slices = _norm_slice_spec(len(ref), slice_spec)
+
+        # Compute an expanded version of ref that has None values for
+        # any to-be-inserted unit dims. This will be the same size
+        # as slices.
+        self.expanded_ref: list[Optional[SymbolExpr]] = list(ref)
+        for i in (i for i, entry in enumerate(self.slices) if entry is None):
+            self.expanded_ref.insert(i, None)
+        assert len(self.expanded_ref) == len(self.slices)
+        self._is_symbolic_normalized = False
+
+    def __repr__(self):
+        return repr(self.slices)
+
+    def normalize_symbolic_ranges(
+        self, *, allow_reverse_step: bool = False, allow_non_unit_step: bool = False
+    ):
+        """Uses the IndexingContext to normalize range for any None fields.
+
+        This fully populates the fields of every slice with either
+        integers or SymbolExprs. Does not modify slice fields that are
+        non-None.
+
+        Raises IndexError for any variations that are not supported
+        or cannot be statically derived.
+        """
+        if self._is_symbolic_normalized:
+            return
+
+        def norm(dim_expr: SymbolExpr, s: Optional[slice]) -> Optional[slice]:
+            if s is None:
+                return s
+            ctx = IndexingContext.current()
+            start = s.start
+            stop = s.stop
+            step = s.step
+
+            # Set defaults.
+            if start is None:
+                start = 0
+            if stop is None:
+                stop = dim_expr
+            if step is None:
+                step = 1
+
+            # Evaluate facts for start.
+            if isinstance(start, SymbolExpr):
+                start_is_non_negative = ctx.is_non_negative(start)
+            elif isinstance(start, int):
+                start_is_non_negative = start >= 0
+            else:
+                raise IndexError(
+                    f"A symbolically evaluable start index is required (got: {start} (type {type(start)}))"
+                )
+
+            # Evaluate facts for stop.
+            if isinstance(stop, SymbolExpr):
+                stop_is_non_negative = ctx.is_non_negative(stop)
+                stop_is_zero = False
+            elif isinstance(stop, int):
+                stop_is_non_negative = stop >= 0
+                stop_is_zero = stop == 0
+            else:
+                raise IndexError(
+                    f"A symbolically evaluable stop index is required (got: {stop} (type {type(stop)}))"
+                )
+
+            # Evaluate facts for step.
+            if isinstance(step, SymbolExpr):
+                reverse_step = ctx.is_negative(step)
+                unit_step = ctx.is_one(step)
+                zero_step = False
+            elif isinstance(step, int):
+                reverse_step = step < 0
+                unit_step = step == 1
+                zero_step = step == 0
+            else:
+                raise IndexError(
+                    f"A symbolically evaluable step is required (got: {step} (type {type(step)}))"
+                )
+
+            # Validate step constraints.
+            if zero_step:
+                # This is our special marker for a unit (non-range extract).
+                assert stop_is_zero, "slices of non zero stop and zero step should have been filtered"
+            else:
+                if not allow_non_unit_step and not unit_step:
+                    raise IndexError(f"Only unit steps are supported in this context (got slice({start}, {stop}, {step}))")
+
+                if not allow_reverse_step and reverse_step:
+                    raise IndexError(f"Only forward steps are supported in this context (got slice({start}, {stop}, {step}))")
+
+            # Normalize negative start/stop.
+            if not start_is_non_negative:
+                raise IndexError(f"NYI: Negative slice start")
+            if not stop_is_non_negative:
+                raise IndexError(f"NYI: Negative slice stop")
+
+            return slice(start, stop, step)
+
+        for i in range(len(self.slices)):
+            expr = self.expanded_ref[i]
+            self.slices[i] = norm(expr, self.slices[i])
+        self._is_symbolic_normalized = True
+
+    @property
+    def symbolic_shape(self) -> tuple[Union[int, SymbolExpr]]:
+        """Resolves the symbolic shape of the result of this slice.
+
+        Forces symbolic normalization if it has not already been done.
+        Any rank broadcast dimensions will be retained as None.
+        """
+        self.normalize_symbolic_ranges()
+
+        def _item(s: Optional[slice]):
+            if s is None:
+                return None
+            ctx = IndexingContext.current()
+            # Detect special unit 0-step slices.
+            if s.stop == 0 and s.step == 0:
+                return 1
+            start = s.start
+            stop = s.stop
+
+            # TODO: This is a hack to work around that I don't have the full
+            # symbolic expression support in yet. We should just be asking
+            # the symbols to evaluate.
+            if isinstance(start, SymbolExpr):
+                static_start = ctx.get_static_value(start)
+            elif isinstance(start, int):
+                static_start = start
+            if isinstance(stop, SymbolExpr):
+                static_stop = ctx.get_static_value(stop)
+            elif isinstance(stop, int):
+                static_stop = stop
+            if static_start is not None and static_stop is not None:
+                return static_stop - static_start
+
+            raise IndexError(f"NYI: Non-statically resolved symbolic shapes")
+
+        return [_item(s) for s in self.slices]

--- a/python/shark_turbine/kernel/compiler/base.py
+++ b/python/shark_turbine/kernel/compiler/base.py
@@ -1,0 +1,6 @@
+class CodegenError(Exception):
+    ...
+
+
+class ValidationError(CodegenError):
+    ...

--- a/python/shark_turbine/kernel/compiler/builder.py
+++ b/python/shark_turbine/kernel/compiler/builder.py
@@ -1,9 +1,21 @@
 from typing import Optional
 
+from .base import (
+    CodegenError,
+)
+
 from .ir import (
+    Attribute,
     Context,
+    FloatAttr,
+    IndexType,
+    IntegerAttr,
+    IntegerType,
+    IrType,
     Location,
     Operation,
+    Value,
+    arith_d,
     builtin_d,
 )
 
@@ -13,7 +25,7 @@ class ModuleBuilder:
         self,
         *,
         context: Optional[Context] = None,
-        module_op: Optional[Operation] = None
+        module_op: Optional[Operation] = None,
     ):
         if module_op:
             self.module_op = module_op
@@ -24,3 +36,83 @@ class ModuleBuilder:
             self.module_op = builtin_d.ModuleOp(loc=Location.unknown(context))
             self.body_block = self.module_op.body
         self.context = self.module_op.context
+
+
+class _ScalarBuilder:
+    def promote(self, value: Value, to_type: IrType) -> Value:
+        value_type = value.type
+        # Short-circuit if already the right type.
+        if value_type == to_type:
+            return value
+
+        attr_name = f"promote_{value_type}_to_{to_type}"
+        try:
+            handler = getattr(self, attr_name)
+        except AttributeError:
+            raise CodegenError(
+                f"No implemented path to implicitly promote scalar `{value_type}` to `{to_type}` (tried '{attr_name}')"
+            )
+        return handler(value, to_type)
+
+    def zero_attr(self, t: IrType) -> Attribute:
+        attr_name = f"zero_attr_{t}"
+        try:
+            handler = getattr(self, attr_name)
+        except AttributeError:
+            raise CodegenError(
+                f"Cannot derive a zero value for type `{t}` (tried '{attr_name}')"
+            )
+        return handler(t)
+
+    def constant(self, py_value) -> Value:
+        attr_name = f"py_constant_{type(py_value).__name__}"
+        try:
+            handler = getattr(self, attr_name)
+        except AttributeError:
+            raise CodegenError(
+                f"Cannot convert Python value to constant: {py_value} of type {type(py_value)} (tried '{attr_name}')"
+            )
+        return handler(py_value)
+
+    def binary_arithmetic(self, op: str, lhs: Value, rhs: Value) -> Value:
+        attr_name = f"binary_{op}_{lhs.type}_{rhs.type}"
+        try:
+            handler = getattr(self, attr_name)
+        except AttributeError:
+            raise CodegenError(
+                f"Cannot perform binary arithmetic operation '{op}' between {lhs.type} and {rhs.type} (tried '{attr_name}')"
+            )
+        return handler(lhs, rhs)
+
+    def promote_index_to_f32(self, value: Value, to_type: IrType) -> Value:
+        i32_type = IntegerType.get_signless(32)
+        i32 = arith_d.index_cast(i32_type, value)
+        return arith_d.sitofp(to_type, i32)
+
+    def zero_attr_f32(self, t: IrType) -> Attribute:
+        return FloatAttr.get(t, 0.0)
+
+    def py_constant_int(self, py_value) -> Value:
+        # If coming from a stock 'int' Python type with no idea how to convert it,
+        # there isn't much smart we can do. We conservatively treat 'index' as
+        # reasonable.
+        attr = IntegerAttr.get(IndexType.get(), py_value)
+        return arith_d.constant(attr)
+
+    def binary_add_index_index(self, lhs: Value, rhs: Value) -> Value:
+        return arith_d.addi(lhs, rhs)
+
+    def binary_mul_index_index(self, lhs: Value, rhs: Value) -> Value:
+        return arith_d.muli(lhs, rhs)
+
+    def binary_sub_index_index(self, lhs: Value, rhs: Value) -> Value:
+        return arith_d.subi(lhs, rhs)
+
+    def binary_mod_index_index(self, lhs: Value, rhs: Value) -> Value:
+        return arith_d.remsi(lhs, rhs)
+
+    def binary_floordiv_index_index(self, lhs: Value, rhs: Value) -> Value:
+        return arith_d.floordivsi(lhs, rhs)
+
+
+ScalarBuilder = _ScalarBuilder()

--- a/python/shark_turbine/kernel/compiler/ir.py
+++ b/python/shark_turbine/kernel/compiler/ir.py
@@ -26,5 +26,6 @@ from iree.compiler.dialects import (
     arith as arith_d,
     builtin as builtin_d,
     func as func_d,
+    math as math_d,
     vector as vector_d,
 )

--- a/python/shark_turbine/kernel/compiler/op_matchers.py
+++ b/python/shark_turbine/kernel/compiler/op_matchers.py
@@ -1,0 +1,64 @@
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+import functools
+import inspect
+
+
+def signature_matcher(f=None, *, arity: Optional[int] = None, original_name: str = ""):
+    """Transforms a function into a signature matcher.
+
+    The transfored function takes the same args/kwargs as the original, but
+    it will return an inspect.BoundArguments.arguments when invoked.
+
+    Optional overload selectors can be specified, and if not met, None
+    will be returned (versus raising an error).
+
+    On argument mismatch, a TypeError will be raised.
+    """
+    if f is None:
+        return functools.partial(
+            signature_matcher, arity=arity, original_name=original_name
+        )
+
+    sig = inspect.signature(f)
+
+    def wrapped(*args, **kwargs) -> Optional[inspect.BoundArguments]:
+        if arity is not None and arity != (len(args) + len(kwargs)):
+            return None
+        try:
+            bound_args = sig.bind(*args, **kwargs)
+            bound_args.apply_defaults()
+            return bound_args.arguments
+        except TypeError as e:
+            reported_name = original_name or f.__name__
+            raise TypeError(f"{reported_name}() {str(e)}")
+
+    return wrapped
+
+
+@signature_matcher(original_name="torch.exp")
+def torch_exp(input: Tensor) -> Tensor:
+    ...
+
+
+@signature_matcher(arity=1, original_name="torch.max")
+def torch_max_unary(input: Tensor) -> Tensor:
+    ...
+
+
+@signature_matcher(original_name="torch.max")
+def torch_max(input: Tensor, dim: int, keepdim: bool = False):
+    ...
+
+
+@signature_matcher(arity=1, original_name="torch.sum")
+def torch_sum_unary(input: Tensor) -> Tensor:
+    ...
+
+
+@signature_matcher(original_name="torch.sum")
+def torch_sum(input: Tensor, dim: int, keepdim: bool = False):
+    ...

--- a/python/shark_turbine/kernel/gen/thread.py
+++ b/python/shark_turbine/kernel/gen/thread.py
@@ -32,7 +32,7 @@ def thread(*symbolic_shape: SymbolDef):
     def decorator(f: Optional[TCallable] = None) -> "UnconfiguredThread[TCallable]":
         # Eagerly capture the trace and attach it to the wrapped function.
         tracer = KernelTracer()
-        with CompiledContext(tracer) as context:
+        with CompiledContext(tracer, grid_type=GridType) as context:
             g = tracer.trace(f)
             gm = fx.GraphModule(tracer.root, g, f.__name__)
 

--- a/tests/kernel/analysis_test.py
+++ b/tests/kernel/analysis_test.py
@@ -1,0 +1,65 @@
+import logging
+import unittest
+
+
+from shark_turbine.kernel._support.indexing import (
+    IndexingContext,
+    sym,
+)
+
+from shark_turbine.kernel.compiler.analysis import (
+    SliceAnalysis,
+    _norm_slice_spec,
+)
+
+M = sym.M
+N = sym.N
+K = sym.K
+
+
+class SliceAnalysisTest(unittest.TestCase):
+    def testNorm(self):
+        self.assertEqual([slice(1, 0, 0)], (_norm_slice_spec(1, 1)))
+        self.assertEqual([slice(1, 0, 0)], (_norm_slice_spec(1, (1,))))
+        self.assertEqual(
+            [slice(1, None, None)], (_norm_slice_spec(1, (slice(1, None))))
+        )
+        self.assertEqual([None, slice(2, 0, 0)], (_norm_slice_spec(2, (None, 2))))
+        self.assertEqual(
+            [slice(1, 0, 0), slice(2, 0, 0)],
+            (_norm_slice_spec(2, (1, ..., 2))),
+        )
+        self.assertEqual(
+            [slice(1, 0, 0), slice(2, 0, 0)],
+            (_norm_slice_spec(1, (1, ..., 2))),
+        )
+        self.assertEqual(
+            [
+                None,
+                slice(None, None, None),
+                slice(None, None, None),
+                slice(None, None, None),
+                slice(None, None, None),
+                slice(2, 0, 0),
+            ],
+            (_norm_slice_spec(5, (None, ..., 2))),
+        )
+
+    def testSymbolic(self):
+        with IndexingContext() as ctx:
+            ctx.bind_constant(M, 20)
+            ctx.bind_constant(N, 30)
+            ctx.bind_constant(K, 5)
+
+            sa = SliceAnalysis((M, N, K), (1, slice(None), slice(2, K), None))
+            sa.normalize_symbolic_ranges()
+            self.assertEqual(
+                "[slice(1, 0, 0), slice(0, Symbol(N), 1), slice(2, Symbol(K), 1), None]",
+                repr(sa.slices),
+            )
+            self.assertEqual([1, 30, 3, None], sa.symbolic_shape)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/tests/kernel/indexing_test.py
+++ b/tests/kernel/indexing_test.py
@@ -65,6 +65,13 @@ class Test(unittest.TestCase):
         T = InputBuffer[M].of(torch.float16)
         self.assertEqual("InputBuffer[M].of(torch.float16)", repr(T))
 
+    def testBoundedSymbolValue(self):
+        self.assertEqual("BoundedSymbolicValue(* : *)", (repr(BoundedSymbolicValue)))
+        B1 = BoundedSymbolicValue.bound(sym_0, None)
+        self.assertEqual("BoundedSymbolicValue(Symbol(0) : *)", repr(B1))
+        B2 = B1.narrow(max_bound=sym_1)
+        self.assertEqual("BoundedSymbolicValue(Symbol(0) : Symbol(1))", repr(B2))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/kernel/vector_codegen_test.py
+++ b/tests/kernel/vector_codegen_test.py
@@ -1,6 +1,7 @@
 import logging
 import unittest
 
+import torch
 import shark_turbine.kernel as tk
 
 from shark_turbine.kernel.compiler import (
@@ -37,6 +38,37 @@ class Test(unittest.TestCase):
             print(sig)
             try:
                 emitter = vector_codegen.ThreadEmitter(mb, iota_kernel.grid_type, sig)
+                emitter.emit_graph(gm.graph)
+                emitter.finish()
+            finally:
+                print(mb.module_op.get_asm())
+            mb.module_op.verify()
+
+    def testSoftmaxFx(self):
+        @tk.gen.thread(M)
+        def softmax_kernel(
+            input: tk.lang.KernelBuffer[M, K], output: tk.lang.KernelBuffer[M, K]
+        ):
+            row_index = tk.lang.program_id(0)
+            input_row = input[row_index, :]
+            numerator = torch.exp(input_row - torch.max(input_row))
+            output_row = numerator / torch.sum(numerator)
+            output[row_index, :] = output_row
+
+        gm = softmax_kernel._trace.gm
+        print(gm.graph)
+        mb = builder.ModuleBuilder()
+        with indexing.IndexingContext() as idxc:
+            idxc.bind_constant(M, 17)
+
+            sig = vector_codegen.Signature()
+            sig.add_from_graph_placeholders(gm.graph)
+            sig.add_grid(softmax_kernel.grid_type)
+            print(sig)
+            try:
+                emitter = vector_codegen.ThreadEmitter(
+                    mb, softmax_kernel.grid_type, sig
+                )
                 emitter.emit_graph(gm.graph)
                 emitter.finish()
             finally:

--- a/tests/kernel/vector_codegen_test.py
+++ b/tests/kernel/vector_codegen_test.py
@@ -59,7 +59,8 @@ class Test(unittest.TestCase):
         print(gm.graph)
         mb = builder.ModuleBuilder()
         with indexing.IndexingContext() as idxc:
-            idxc.bind_constant(M, 17)
+            idxc.bind_constant(M, 128)
+            idxc.bind_constant(K, 64)
 
             sig = vector_codegen.Signature()
             sig.add_from_graph_placeholders(gm.graph)
@@ -70,8 +71,8 @@ class Test(unittest.TestCase):
                     mb, softmax_kernel.grid_type, sig
                 )
                 emitter.emit_graph(gm.graph)
-                emitter.finish()
             finally:
+                emitter.finish()
                 print(mb.module_op.get_asm())
             mb.module_op.verify()
 


### PR DESCRIPTION
* Adds arithmetic binary broadcast.
* Adds f32 arithmetic.
* Handles torch ops exp, max, sum (only reduce to scalar at the moment).
* General python signature validation and unpacking.
* Some initial attribute propagation work needed to handle unsigned properly.
* A start at full generality for symbolic dimensions and slice analysis. Needs to be reworked before too long but this gets us basic functionality on static kernels while leaving room for dynamic to emerge.
