### PR TITLE
[TK] Subgraph Tracing to support control flow

### DIFF
--- a/python/shark_turbine/kernel/_support/indexing.py
+++ b/python/shark_turbine/kernel/_support/indexing.py
@@ -41,7 +41,7 @@ SubtypeT = TypeVar("SubtypeT")
 class ElementType(ABC):
     @staticmethod
     def cast(something) -> "ElementType":
-        if isinstance(something, torch.dtyp):
+        if isinstance(something, torch.dtype):
             return TorchElementType(something)
         else:
             raise TypeError(

--- a/python/shark_turbine/kernel/_support/regions.py
+++ b/python/shark_turbine/kernel/_support/regions.py
@@ -1,15 +1,26 @@
-from typing import Optional, TypeVar, Callable, Type, assert_type, cast, List, Dict, Tuple
+from typing import (
+    Optional,
+    TypeVar,
+    Callable,
+    Type,
+    assert_type,
+    cast,
+    List,
+    Dict,
+    Tuple,
+)
 import random
 import contextlib
 
 import torch.fx as fx
 import torch.utils._pytree as pytree
 
+
 class RegionGraph:
     def __init__(self):
-        self.tracers : List["SubgraphTracer"] = []
-        self.subgraphs : Dict[str, fx.Graph] = dict()
-        self.inner_freevars : Dict[fx.Graph, List[fx.Proxy]] = dict()
+        self.tracers: List["SubgraphTracer"] = []
+        self.subgraphs: Dict[str, fx.Graph] = dict()
+        self.inner_freevars: Dict[fx.Graph, List[fx.Proxy]] = dict()
 
     @property
     def root_tracer(self) -> "SubgraphTracer":
@@ -28,13 +39,17 @@ class RegionGraph:
     def create_arg(self, *args, **kwargs):
         return self.current_tracer.create_arg(*args, **kwargs)
 
-    def new_subtracer(self, region_graph: "RegionGraph", parent : Optional["SubgraphTracer"] = None) -> "SubgraphTracer":
+    def new_subtracer(
+        self, region_graph: "RegionGraph", parent: Optional["SubgraphTracer"] = None
+    ) -> "SubgraphTracer":
         ...
 
     ### ========================================================================
     ### Subgraph Tracing
     ### ========================================================================
-    def add_subgraph(self, name : str, graph: fx.Graph, inner_freevars : List[fx.Proxy]) -> str:
+    def add_subgraph(
+        self, name: str, graph: fx.Graph, inner_freevars: List[fx.Proxy]
+    ) -> str:
         i = 0
         while True:
             candidate_name = f"{name}_{i}"
@@ -62,8 +77,11 @@ class RegionGraph:
             out += "\n"
         return out
 
+
 class SubgraphTracer(fx.Tracer):
-    def __init__(self, region_graph: RegionGraph, parent : Optional["SubgraphTracer"] = None):
+    def __init__(
+        self, region_graph: RegionGraph, parent: Optional["SubgraphTracer"] = None
+    ):
         super().__init__()
         self.graph = fx.Graph()
         self.region_graph = region_graph
@@ -83,9 +101,9 @@ class SubgraphTracer(fx.Tracer):
         proxy.node.meta["lifted"] = None
         return proxy
 
-    def _lift_tracked_freevar_to_input(self, proxy : fx.Proxy):
+    def _lift_tracked_freevar_to_input(self, proxy: fx.Proxy):
         # It makes no sense for the root graph to have free variables
-        assert(self.parent is not None), "Cannot lift freevars to input in root tracer"
+        assert self.parent is not None, "Cannot lift freevars to input in root tracer"
 
         # If the freevar has already been lifted, return the lifted version.
         if proxy in self.lifted_freevars:
@@ -113,14 +131,14 @@ class SubgraphTracer(fx.Tracer):
             return self._lift_tracked_freevar_to_input(arg)
 
     def create_proxy(
-            self,
-            kind,
-            target,
-            args,
-            kwargs,
-            name=None,
-            type_expr=None,
-            proxy_factor_fn=None,
+        self,
+        kind,
+        target,
+        args,
+        kwargs,
+        name=None,
+        type_expr=None,
+        proxy_factor_fn=None,
     ):
         if self.parent is not None:
             flat_args, tree_spec = pytree.tree_flatten((args, kwargs))

--- a/python/shark_turbine/kernel/_support/regions.py
+++ b/python/shark_turbine/kernel/_support/regions.py
@@ -1,0 +1,143 @@
+from typing import Optional, TypeVar, Callable, Type, assert_type, cast, List, Dict, Tuple
+import random
+import contextlib
+
+import torch.fx as fx
+import torch.utils._pytree as pytree
+
+class RegionGraph:
+    def __init__(self):
+        self.tracers : List["SubgraphTracer"] = []
+        self.subgraphs : Dict[str, fx.Graph] = dict()
+        self.inner_freevars : Dict[fx.Graph, List[fx.Proxy]] = dict()
+
+    @property
+    def root_tracer(self) -> "SubgraphTracer":
+        return self.tracers[0]
+
+    @property
+    def current_tracer(self) -> "SubgraphTracer":
+        return self.tracers[-1]
+
+    def create_proxy(self, *args, **kwargs):
+        return self.current_tracer.create_proxy(*args, **kwargs)
+
+    def create_node(self, *args, **kwargs):
+        return self.current_tracer.create_node(*args, **kwargs)
+
+    def create_arg(self, *args, **kwargs):
+        return self.current_tracer.create_arg(*args, **kwargs)
+
+    def new_subtracer(self, region_graph: "RegionGraph", parent : Optional["SubgraphTracer"] = None) -> "SubgraphTracer":
+        ...
+
+    ### ========================================================================
+    ### Subgraph Tracing
+    ### ========================================================================
+    def add_subgraph(self, name : str, graph: fx.Graph, inner_freevars : List[fx.Proxy]) -> str:
+        i = 0
+        while True:
+            candidate_name = f"{name}_{i}"
+            i += 1
+            if candidate_name not in self.subgraphs:
+                self.subgraphs[candidate_name] = graph
+                self.inner_freevars[graph] = inner_freevars
+                return candidate_name
+
+    @contextlib.contextmanager
+    def subtracer(self):
+        if self.tracers:
+            new_tracer = self.new_subtracer(self, self.current_tracer)
+        else:
+            new_tracer = self.new_subtracer(self)
+        self.tracers.append(new_tracer)
+        yield new_tracer
+        self.tracers.pop()
+
+    def __str__(self):
+        out = ""
+        for name, subgraph in self.subgraphs.items():
+            out += f"{name}:"
+            out += str(subgraph)
+            out += "\n"
+        return out
+
+class SubgraphTracer(fx.Tracer):
+    def __init__(self, region_graph: RegionGraph, parent : Optional["SubgraphTracer"] = None):
+        super().__init__()
+        self.graph = fx.Graph()
+        self.region_graph = region_graph
+        self.parent = parent
+        self.lifted_freevars: Dict[fx.Proxy, fx.Proxy] = {}
+
+    def trace(self, *args, **kwargs) -> Tuple[str, List[fx.Proxy]]:
+        traced = super().trace(*args, **kwargs)
+        inner_freevars = list(self.lifted_freevars.values())
+        implicit_capture = list(self.lifted_freevars.keys())
+        subgraph_name = self.region_graph.add_subgraph("region", traced, inner_freevars)
+        return subgraph_name, implicit_capture
+
+    def _create_graph_input(self, name: str, type_expr=None) -> fx.Proxy:
+        proxy = self.create_proxy("placeholder", name, (), {}, type_expr=type_expr)
+        # Can use this to check where the freevar has been lifted from.
+        proxy.node.meta["lifted"] = None
+        return proxy
+
+    def _lift_tracked_freevar_to_input(self, proxy : fx.Proxy):
+        # It makes no sense for the root graph to have free variables
+        assert(self.parent is not None), "Cannot lift freevars to input in root tracer"
+
+        # If the freevar has already been lifted, return the lifted version.
+        if proxy in self.lifted_freevars:
+            return self.lifted_freevars[proxy]
+
+        # Otherwise, create a new input and store it.
+        new_proxy = self._create_graph_input(proxy.node.name, proxy.node.type)
+        self.lifted_freevars[proxy] = new_proxy
+
+        # Propagate freevar usage upwards.
+        if self.parent is not None and proxy.tracer != self.parent:
+            self.parent._lift_tracked_freevar_to_input(proxy)
+        return new_proxy
+
+    def _maybe_lift_tracked_freevar_to_input(self, arg):
+        """
+        If arg is a free variable, then lift it to be an input.
+        Returns the new lifted arg (if lifted), else the original arg.
+        """
+        if not isinstance(arg, fx.Proxy):
+            return arg
+        elif arg.tracer == self:
+            return arg
+        else:
+            return self._lift_tracked_freevar_to_input(arg)
+
+    def create_proxy(
+            self,
+            kind,
+            target,
+            args,
+            kwargs,
+            name=None,
+            type_expr=None,
+            proxy_factor_fn=None,
+    ):
+        if self.parent is not None:
+            flat_args, tree_spec = pytree.tree_flatten((args, kwargs))
+            new_flat_args = []
+            for arg in flat_args:
+                maybe_new_arg = self._maybe_lift_tracked_freevar_to_input(arg)
+                new_flat_args.append(maybe_new_arg)
+            args, kwargs = pytree.tree_unflatten(new_flat_args, tree_spec)
+
+        rv = super().create_proxy(
+            kind,
+            target,
+            args,
+            kwargs,
+            name,
+            type_expr,
+            proxy_factor_fn,
+        )
+
+        return rv

--- a/python/shark_turbine/kernel/_support/tracing.py
+++ b/python/shark_turbine/kernel/_support/tracing.py
@@ -144,14 +144,10 @@ class EagerContext(BaseContext):
         assert axis >= 0 and axis < self.rank
         return Index(self.current_thread[axis])
 
-    def handle_kernel_buffer_getitem(
-        self, op, kernel_buffer: KernelBuffer, key
-    ):
+    def handle_kernel_buffer_getitem(self, op, kernel_buffer: KernelBuffer, key):
         return kernel_buffer._tensor.__getitem__(key)
 
-    def handle_kernel_buffer_setitem(
-        self, op, kernel_buffer: KernelBuffer, key, item
-    ):
+    def handle_kernel_buffer_setitem(self, op, kernel_buffer: KernelBuffer, key, item):
         kernel_buffer._tensor.__setitem__(key, item)
 
 
@@ -180,9 +176,7 @@ class CompiledContext(BaseContext):
         )
         return proxy
 
-    def handle_kernel_buffer_getitem(
-        self, op, kernel_buffer: KernelBuffer, key
-    ):
+    def handle_kernel_buffer_getitem(self, op, kernel_buffer: KernelBuffer, key):
         return self.region_graph.create_proxy(
             "call_function",
             op,
@@ -190,9 +184,7 @@ class CompiledContext(BaseContext):
             kwargs={},
         )
 
-    def handle_kernel_buffer_setitem(
-        self, op, kernel_buffer: KernelBuffer, key, item
-    ):
+    def handle_kernel_buffer_setitem(self, op, kernel_buffer: KernelBuffer, key, item):
         self.region_graph.create_proxy(
             "call_function",
             target=op,

--- a/python/shark_turbine/kernel/_support/tracing.py
+++ b/python/shark_turbine/kernel/_support/tracing.py
@@ -172,6 +172,25 @@ class CompiledContext(BaseContext):
         )
 
     ### ========================================================================
+    ### Memory Operations
+    ### ========================================================================
+    def handle_kernel_buffer_load(self, kernel_buffer, multi_index, shape):
+        return self.region_graph.create_proxy(
+            "call_function",
+            target=ops.kernel_buffer_load,
+            args=(kernel_buffer, multi_index, shape),
+            kwargs={},
+        )
+
+    def handle_kernel_buffer_store(self, kernel_buffer, multi_index, item):
+        self.region_graph.create_proxy(
+            "call_function",
+            target=ops.kernel_buffer_store,
+            args=(kernel_buffer, multi_index, item),
+            kwargs={},
+        )
+
+    ### ========================================================================
     ### Control Flow Operations
     ### ========================================================================
     def handle_for_loop(self, op, start, stop = None, step = None, init_args = []):
@@ -242,6 +261,14 @@ class CompiledContext(BaseContext):
             kwargs={},
         )
 
+    def handle_vector_zeros(self, op, shape: Tuple[int, ...]):
+        return self.region_graph.create_proxy(
+            "call_function",
+            target=op,
+            args=(shape,),
+            kwargs={},
+        )
+
     ### ========================================================================
     ### Reduction Operations
     ### ========================================================================
@@ -259,6 +286,14 @@ class CompiledContext(BaseContext):
             "call_function",
             target=op,
             args=(source, dims),
+            kwargs={},
+        )
+
+    def handle_vector_dot(self, op, lhs, rhs):
+        return self.region_graph.create_proxy(
+            "call_function",
+            target=op,
+            args=(lhs, rhs),
             kwargs={},
         )
 

--- a/python/shark_turbine/kernel/_support/tracing.py
+++ b/python/shark_turbine/kernel/_support/tracing.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, TypeVar, Callable, Type, assert_type, cast
+from typing import Optional, TypeVar, Callable, Type, assert_type, cast, List
 
 import functools
 import warnings
@@ -15,6 +15,7 @@ from .indexing import (
 
 from ..lang.types import (
     Index,
+    Vector,
 )
 
 from .. import ops
@@ -114,6 +115,10 @@ class CompiledContext(BaseContext):
         self.tracer = tracer
         self.grid_type = grid_type
 
+    ### ========================================================================
+    ### Core Operations
+    ### ========================================================================
+
     def handle_thread_program_id(self, op, axis: int) -> Index:
         grid_shape = self.grid_type.symbolic_shape
         if axis < 0 or axis >= len(grid_shape):
@@ -142,6 +147,70 @@ class CompiledContext(BaseContext):
             "call_function",
             target=op,
             args=(kernel_buffer, key, item),
+            kwargs={},
+        )
+
+    ### ========================================================================
+    ### Math Operations
+    ### ========================================================================
+
+    def handle_vector_add(self, op, lhs: Vector, rhs: Vector):
+        return self.tracer.create_proxy(
+            "call_function",
+            target=op,
+            args=(lhs, rhs),
+            kwargs={},
+        )
+
+    def handle_vector_sub(self, op, lhs: Vector, rhs: Vector):
+        return self.tracer.create_proxy(
+            "call_function",
+            target=op,
+            args=(lhs, rhs),
+            kwargs={},
+        )
+
+    def handle_vector_mul(self, op, lhs: Vector, rhs: Vector):
+        return self.tracer.create_proxy(
+            "call_function",
+            target=op,
+            args=(lhs, rhs),
+            kwargs={},
+        )
+
+    def handle_vector_div(self, op, lhs: Vector, rhs: Vector):
+        return self.tracer.create_proxy(
+            "call_function",
+            target=op,
+            args=(lhs, rhs),
+            kwargs={},
+        )
+
+    def handle_vector_exp(self, op, source: Vector):
+        return self.tracer.create_proxy(
+            "call_function",
+            target=op,
+            args=(source,),
+            kwargs={},
+        )
+
+    ### ========================================================================
+    ### Reduction Operations
+    ### ========================================================================
+
+    def handle_vector_max(self, op, source: Vector, dims: List[int]):
+        return self.tracer.create_proxy(
+            "call_function",
+            target=op,
+            args=(source, dims),
+            kwargs={},
+        )
+
+    def handle_vector_sum(self, op, source: Vector, dims: List[int]):
+        return self.tracer.create_proxy(
+            "call_function",
+            target=op,
+            args=(source, dims),
             kwargs={},
         )
 

--- a/python/shark_turbine/kernel/_support/tracing.py
+++ b/python/shark_turbine/kernel/_support/tracing.py
@@ -214,6 +214,7 @@ class CompiledContext(BaseContext):
     ### ========================================================================
     ### Control Flow Operations
     ### ========================================================================
+
     def handle_for_loop(self, op, start, stop=None, step=None, init_args=[]):
         if stop is None:
             stop = start
@@ -243,46 +244,6 @@ class CompiledContext(BaseContext):
     ### Math Operations
     ### ========================================================================
 
-    def handle_vector_add(self, op, lhs: Vector, rhs: Vector):
-        return self.region_graph.create_proxy(
-            "call_function",
-            target=op,
-            args=(lhs, rhs),
-            kwargs={},
-        )
-
-    def handle_vector_sub(self, op, lhs: Vector, rhs: Vector):
-        return self.region_graph.create_proxy(
-            "call_function",
-            target=op,
-            args=(lhs, rhs),
-            kwargs={},
-        )
-
-    def handle_vector_mul(self, op, lhs: Vector, rhs: Vector):
-        return self.region_graph.create_proxy(
-            "call_function",
-            target=op,
-            args=(lhs, rhs),
-            kwargs={},
-        )
-
-    def handle_vector_div(self, op, lhs: Vector, rhs: Vector):
-        return self.region_graph.create_proxy(
-            "call_function",
-            target=op,
-            args=(lhs, rhs),
-            kwargs={},
-        )
-
-    def handle_vector_exp(self, op, source: Vector):
-        return self.region_graph.create_proxy(
-            "call_function",
-            target=op,
-            args=(source,),
-            kwargs={},
-        )
-
     def handle_vector_constant(
         self, op, shape: Tuple[int, ...], dtype, value: int | float
     ):
@@ -296,22 +257,6 @@ class CompiledContext(BaseContext):
     ### ========================================================================
     ### Reduction Operations
     ### ========================================================================
-
-    def handle_vector_max(self, op, source: Vector, dims: List[int]):
-        return self.region_graph.create_proxy(
-            "call_function",
-            target=op,
-            args=(source, dims),
-            kwargs={},
-        )
-
-    def handle_vector_sum(self, op, source: Vector, dims: List[int]):
-        return self.region_graph.create_proxy(
-            "call_function",
-            target=op,
-            args=(source, dims),
-            kwargs={},
-        )
 
     def handle_vector_dot(self, op, lhs, rhs, acc):
         return self.region_graph.create_proxy(

--- a/python/shark_turbine/kernel/compiler/analysis.py
+++ b/python/shark_turbine/kernel/compiler/analysis.py
@@ -146,6 +146,8 @@ class SliceAnalysis:
             stop_sym = _symbolize_slice_value(stop)
             step_sym = _symbolize_slice_value(step)
 
+            return slice(start, stop, step)
+
             # Evaluate facts for start.
             if isinstance(start_sym, SymbolExpr):
                 start_is_non_negative = start_sym.is_non_negative()

--- a/python/shark_turbine/kernel/compiler/ir.py
+++ b/python/shark_turbine/kernel/compiler/ir.py
@@ -4,6 +4,7 @@ from iree.compiler.ir import (
     AffineMap,
     AffineMapAttr,
     Attribute,
+    ArrayAttr,
     Block,
     Context,
     DenseElementsAttr,

--- a/python/shark_turbine/kernel/compiler/ir.py
+++ b/python/shark_turbine/kernel/compiler/ir.py
@@ -33,4 +33,5 @@ from iree.compiler.dialects import (
     math as math_d,
     stream as stream_d,
     vector as vector_d,
+    scf as scf_d,
 )

--- a/python/shark_turbine/kernel/compiler/vector_codegen.py
+++ b/python/shark_turbine/kernel/compiler/vector_codegen.py
@@ -4,7 +4,7 @@ Such kernels operate on global memory at the boundary, scheduling
 actual loads/stores/computes to local vectors using PyTorch tensor
 level operations executed as threads over a grid.
 """
-from typing import Any, Callable, Type, Optional, Sequence, Union
+from typing import Any, Callable, Type, Optional, Sequence, Union, List
 
 from dataclasses import dataclass
 import inspect
@@ -12,6 +12,7 @@ import operator as py_operator
 
 import torch
 import torch.fx as fx
+import torch.utils._pytree as pytree
 
 from .._support.indexing import (
     Grid,
@@ -20,6 +21,10 @@ from .._support.indexing import (
     SymbolDef,
     is_kernel_buffer_meta_derived,
 )
+
+from .._support.tracing import CapturedTrace
+
+from .. import lang as tkl
 
 from ..lang import (
     Index,
@@ -57,6 +62,7 @@ from .ir import (
     func_d,
     math_d,
     vector_d,
+    scf_d,
 )
 
 from .kernel_codegen import (
@@ -89,27 +95,28 @@ class ThreadEmitter:
 
     OP_HANDLERS: dict[Any, Callable[["ThreadEmitter", fx.Node], None]] = {}
 
-    def __init__(self, sig: BoundKernelSignature):
-        self._node_values: dict[fx.Node, Value] = {}
+    def __init__(self, root_sig: BoundKernelSignature, trace: CapturedTrace):
+        self._node_values: dict[fx.Node, List[Value]] = {}
         self._grid_axis_values: dict[int, Value] = {}
-        self._sig = sig
-        self.ip = InsertionPoint(sig.entry_block)
+        self._root_sig = root_sig
+        self.trace = trace
+        self.ip = InsertionPoint(root_sig.entry_block)
 
-    def lookup_node_value(self, node: fx.Node) -> Value:
-        value = self._node_values.get(node)
-        if value is None:
-            value = self._sig.resolve_by_reference(("node", node))
-            self._node_values[node] = value
-        return value
+    def lookup_node_values(self, node: fx.Node) -> List[Value]:
+        values = self._node_values.get(node)
+        if values is None:
+            values = [self._root_sig.resolve_by_reference(("node", node))]
+            self._node_values[node] = values
+        return values
 
     def lookup_grid_axis_value(self, grid_axis: int) -> Value:
         value = self._grid_axis_values.get(grid_axis)
         if value is None:
             try:
-                value = self._sig.resolve_by_reference(("grid", grid_axis))
+                value = self._root_sig.resolve_by_reference(("grid", grid_axis))
             except KeyError:
                 raise CodegenError(f"Grid axis {grid_axis} out of bounds")
-            self._node_values[grid_axis] = value
+            self._node_values[grid_axis] = [value]
         return value
 
     def bind_node_result(
@@ -120,14 +127,21 @@ class ThreadEmitter:
         ), f"Cannot rebind node {node}: already bound"
         if attrs is not None:
             attrs.store(node)
-        self._node_values[node] = value
+        self._node_values[node] = [value]
 
-    def emit_graph(self, graph: fx.Graph):
-        for node in graph.nodes:
-            # TODO: Construct a location for the node.
-            with self.ip, Location.unknown():
-                if node.op == "call_function":
-                    self.emit_function_call_node(node)
+    def bind_node_results(
+        self, node: fx.Node, values: List[Value], *, attrs: Optional[NodeAttrs] = None
+    ):
+        assert (
+            node not in self._node_values
+        ), f"Cannot rebind node {node}: already bound"
+        if attrs is not None:
+            attrs.store(node)
+        self._node_values[node] = values
+
+    def emit(self):
+        with self.ip, Location.unknown():
+            self.emit_graph(self.trace.get_root_graph())
 
     def emit_function_call_node(self, node: fx.Node):
         target_op = node.target
@@ -136,6 +150,25 @@ class ThreadEmitter:
         except KeyError:
             raise CodegenError(f"No handler registered for op {target_op}")
         handler(self, node)
+        # dump
+
+    def emit_graph(self, graph: fx.Graph):
+        """Emits the given graph at the current insertion point."""
+        for node in graph.nodes:
+            if node.op == "call_function":
+                self.emit_function_call_node(node)
+            if node.op == "output":
+                return node.args
+
+    def emit_subgraph(self, subgraph: fx.Graph, implicit_capture: list[fx.Node]):
+        # Map subgraph freevars -> implicit_capture
+        freevars = self.trace.region_graph.inner_freevars[subgraph]
+        assert len(freevars) == len(implicit_capture), f"Expected {len(freevars)} implicit capture args, got {len(implicit_capture)}"
+        for freevar, arg in zip(freevars, implicit_capture):
+            self._node_values[freevar.node] = self.lookup_node_values(arg)
+
+        # Emit subgraph
+        return self.emit_graph(subgraph)
 
     def finish(self):
         with self.ip, Location.unknown():
@@ -153,6 +186,19 @@ def handle_op(op):
 ###############################################################################
 # Python/scalar ops
 ###############################################################################
+
+@handle_op(py_operator.getitem)
+def _(emitter: ThreadEmitter, node: fx.Node):
+    try:
+        proxy, index = node.args
+    except ValueError as e:
+        raise ValidationError("Malformed arguements") from e
+
+    if not isinstance(proxy, fx.Node):
+        raise CodegenError(f"Expected fx.Node")
+    node_values = emitter.lookup_node_values(proxy)
+    
+    emitter.bind_node_result(node, node_values[index])
 
 BINARY_ARITHMETIC_OPS = [
     (py_operator.add, "add"),
@@ -303,6 +349,58 @@ def _(emitter: ThreadEmitter, node: fx.Node):
         None, insert_vector, kb_dest, indices, AffineMapAttr.get(permutation_map)
     )
 
+###############################################################################
+# Control Flow ops
+###############################################################################
+
+@handle_op(tkl.for_loop)
+def _(emitter: ThreadEmitter, node: fx.Node):
+    try:
+        start, end, step, init_args = node.args
+        subgraph = node.kwargs["subgraph"]
+        implicit_capture = node.kwargs["implicit_capture"]
+    except ValueError as e:
+        raise ValidationError("Malformed arguments") from e
+
+    # Check if init_args is a flattened list of values.
+    for arg in init_args:
+        if len(emitter.lookup_node_values(arg)) != 1:
+            raise CodegenError(f"NYI: For loop init args must be flattened")
+
+    # Get IR values mapping to the node args.
+    start = cast_py_value(emitter, start)
+    end = cast_py_value(emitter, end)
+    step = cast_py_value(emitter, step)
+
+    # Flatten init_args and get IR values for each of them.
+    flat_init_args, init_args_spec = pytree.tree_flatten((init_args))
+    flat_init_args = [cast_py_value(emitter, arg) for arg in flat_init_args]
+
+    # Get the subgraph for body of the loop.
+    assert isinstance(subgraph, str)
+    subgraph = emitter.trace.get_subgraph(subgraph)
+
+    # Create scf.for operation.
+    forOp = scf_d.ForOp(start, end, step, flat_init_args)
+    # Enter body of for loop.
+    with InsertionPoint(forOp.body):
+        # TODO: Flatten subgraph args here.
+        subgraph_args = [node for node in subgraph.nodes if node.op == "placeholder" and "lifted" not in node.meta]
+        # Add mapping for induction variable argument.
+        emitter.bind_node_result(subgraph_args[0], forOp.induction_variable)
+        # Add mapping for iter_args.
+        emitter.bind_node_results(subgraph_args[1], forOp.inner_iter_args)
+
+        ret = emitter.emit_subgraph(subgraph, implicit_capture)
+        # Use ret in terminatory of body
+        # TODO: Flatten return values here.
+        flat_ret_values, ret_spec = pytree.tree_flatten((ret))
+        flat_ret_values = [cast_py_value(emitter, value) for value in flat_ret_values]
+        scf_d.YieldOp(flat_ret_values)
+
+    results = forOp.results_
+    emitter.bind_node_results(node, results)
+
 
 ###############################################################################
 # Torch and math ops
@@ -384,21 +482,30 @@ def emit_reduction(
 # Conversion utilities
 ###############################################################################
 
-
 def cast_py_value(emitter: ThreadEmitter, value) -> Value:
+    """
+    Converts the given value to an IR Value.
+    If the value is a fx.Node, the result of the fx.Node should corresspond to
+    exactly one IR Value.
+    If the value is a constant, a constant value will be built for it.
+    """
     if isinstance(value, fx.Node):
         try:
-            return emitter.lookup_node_value(value)
+            node_values = emitter.lookup_node_values(value)
+            assert len(node_values) == 1, f"Expected exactly one value for node {value}"
+            return node_values[0]
         except KeyError:
             raise CodegenError(f"Producer node `{value}` has no IR Value")
 
     return ScalarBuilder.constant(value)
 
 
-def cast_py_lvalue(emitter: ThreadEmitter, py_value) -> tuple[Value, fx.Node]:
+def cast_py_lvalue(emitter: ThreadEmitter, py_value : fx.Node) -> tuple[Value, fx.Node]:
     if isinstance(py_value, fx.Node):
         try:
-            return emitter.lookup_node_value(py_value), py_value
+            node_values = emitter.lookup_node_values(py_value)
+            assert len(node_values) == 1, f"Expected exactly one value for node {py_value}"
+            return node_values[0], py_value
         except KeyError:
             raise CodegenError(f"Producer node `{py_value}` has no IR Value")
     else:

--- a/python/shark_turbine/kernel/compiler/vector_codegen.py
+++ b/python/shark_turbine/kernel/compiler/vector_codegen.py
@@ -389,7 +389,7 @@ def _(emitter: ThreadEmitter, node: fx.Node):
     vector_type = VectorType.get(vector_shape, element_type)
     pad_attr = ScalarBuilder.zero_attr(element_type)
     indices = cast_indices(emitter, multi_index)
-    pad_value = arith_d.constant(pad_attr)
+    pad_value = arith_d.constant(element_type, pad_attr)
     result = vector_d.transfer_read(
         vector_type,
         kb_src,

--- a/python/shark_turbine/kernel/gen/thread.py
+++ b/python/shark_turbine/kernel/gen/thread.py
@@ -1,4 +1,14 @@
-from typing import Generic, Optional, Type, TypeVar, Callable, Union, assert_type, cast, Any
+from typing import (
+    Generic,
+    Optional,
+    Type,
+    TypeVar,
+    Callable,
+    Union,
+    assert_type,
+    cast,
+    Any,
+)
 
 import inspect
 import math
@@ -28,12 +38,15 @@ __all__ = [
 
 TCallable = TypeVar("TCallable", bound=Callable)
 
+
 def parameterize(parameters: dict[str, Any]):
     def decorator(f: Optional[TCallable]) -> Optional[TCallable]:
         if f is not None:
             f.parameters = parameters
         return f
+
     return decorator
+
 
 def thread(*symbolic_shape: SymbolDef):
     GridType = Grid[symbolic_shape]

--- a/python/shark_turbine/kernel/gen/thread.py
+++ b/python/shark_turbine/kernel/gen/thread.py
@@ -1,4 +1,4 @@
-from typing import Generic, Optional, Type, TypeVar, Callable, Union, assert_type, cast
+from typing import Generic, Optional, Type, TypeVar, Callable, Union, assert_type, cast, Any
 
 import inspect
 import math
@@ -23,10 +23,17 @@ from .._support.tracing import (
 
 __all__ = [
     "thread",
+    "parameterize",
 ]
 
 TCallable = TypeVar("TCallable", bound=Callable)
 
+def parameterize(parameters: dict[str, Any]):
+    def decorator(f: Optional[TCallable]) -> Optional[TCallable]:
+        if f is not None:
+            f.parameters = parameters
+        return f
+    return decorator
 
 def thread(*symbolic_shape: SymbolDef):
     GridType = Grid[symbolic_shape]

--- a/python/shark_turbine/kernel/lang/prims.py
+++ b/python/shark_turbine/kernel/lang/prims.py
@@ -12,14 +12,7 @@ from .._support.tracing import (
 __all__ = [
     "is_debug",
     "program_id",
-    "add",
-    "sub",
-    "mul",
-    "div",
-    "exp",
     "constant",
-    "max",
-    "sum",
     "dot",
     "for_loop",
     "load",
@@ -32,20 +25,18 @@ def is_debug() -> bool:
     return BaseContext.current().eager
 
 
+# Core language operations
 program_id = ops.thread_program_id
 
-add = ops.vector_add
-sub = ops.vector_sub
-mul = ops.vector_mul
-div = ops.vector_div
-exp = ops.vector_exp
+# Math Operations
 constant = ops.vector_constant
 
-max = ops.vector_max
-sum = ops.vector_sum
+# Reduction Operations
 dot = ops.vector_dot
 
+# Control Flow Operations
 for_loop = ops.for_loop
 
+# Memory Operations
 load = ops.kernel_buffer_load
 store = ops.kernel_buffer_store

--- a/python/shark_turbine/kernel/lang/prims.py
+++ b/python/shark_turbine/kernel/lang/prims.py
@@ -17,9 +17,13 @@ __all__ = [
     "mul",
     "div",
     "exp",
+    "zeros",
     "max",
     "sum",
+    "dot",
     "for_loop",
+    "load",
+    "store"
 ]
 
 
@@ -35,8 +39,13 @@ sub = ops.vector_sub
 mul = ops.vector_mul
 div = ops.vector_div
 exp = ops.vector_exp
+zeros = ops.vector_zeros
 
 max = ops.vector_max
 sum = ops.vector_sum
+dot = ops.vector_dot
 
 for_loop = ops.for_loop
+
+load = ops.kernel_buffer_load
+store = ops.kernel_buffer_store

--- a/python/shark_turbine/kernel/lang/prims.py
+++ b/python/shark_turbine/kernel/lang/prims.py
@@ -17,7 +17,7 @@ __all__ = [
     "mul",
     "div",
     "exp",
-    "zeros",
+    "constant",
     "max",
     "sum",
     "dot",
@@ -39,7 +39,7 @@ sub = ops.vector_sub
 mul = ops.vector_mul
 div = ops.vector_div
 exp = ops.vector_exp
-zeros = ops.vector_zeros
+constant = ops.vector_constant
 
 max = ops.vector_max
 sum = ops.vector_sum

--- a/python/shark_turbine/kernel/lang/prims.py
+++ b/python/shark_turbine/kernel/lang/prims.py
@@ -23,7 +23,7 @@ __all__ = [
     "dot",
     "for_loop",
     "load",
-    "store"
+    "store",
 ]
 
 

--- a/python/shark_turbine/kernel/lang/prims.py
+++ b/python/shark_turbine/kernel/lang/prims.py
@@ -19,6 +19,7 @@ __all__ = [
     "exp",
     "max",
     "sum",
+    "for_loop",
 ]
 
 
@@ -37,3 +38,5 @@ exp = ops.vector_exp
 
 max = ops.vector_max
 sum = ops.vector_sum
+
+for_loop = ops.for_loop

--- a/python/shark_turbine/kernel/lang/prims.py
+++ b/python/shark_turbine/kernel/lang/prims.py
@@ -12,6 +12,13 @@ from .._support.tracing import (
 __all__ = [
     "is_debug",
     "program_id",
+    "add",
+    "sub",
+    "mul",
+    "div",
+    "exp",
+    "max",
+    "sum",
 ]
 
 
@@ -21,3 +28,12 @@ def is_debug() -> bool:
 
 
 program_id = ops.thread_program_id
+
+add = ops.vector_add
+sub = ops.vector_sub
+mul = ops.vector_mul
+div = ops.vector_div
+exp = ops.vector_exp
+
+max = ops.vector_max
+sum = ops.vector_sum

--- a/python/shark_turbine/kernel/lang/types.py
+++ b/python/shark_turbine/kernel/lang/types.py
@@ -38,7 +38,6 @@ class Index(int):
 
     ...
 
-
 class Vector:
     def __add__(self, other: "Vector") -> "Vector":
         return vector_add(self, other)

--- a/python/shark_turbine/kernel/lang/types.py
+++ b/python/shark_turbine/kernel/lang/types.py
@@ -1,7 +1,5 @@
 from typing import Type
 
-from ..ops.math import vector_add, vector_sub, vector_mul, vector_div
-
 
 __all__ = [
     "Index",
@@ -40,14 +38,10 @@ class Index(int):
 
 
 class Vector:
-    def __add__(self, other: "Vector") -> "Vector":
-        return vector_add(self, other)
+    """A tensor like type that is isomorphic to MLIR `vector`.
 
-    def __sub__(self, other: "Vector") -> "Vector":
-        return vector_sub(self, other)
+    A vector has value semantics and allows computation over it.
+    """
 
-    def __mul__(self, other: "Vector") -> "Vector":
-        return vector_mul(self, other)
-
-    def __truediv__(self, other: "Vector") -> "Vector":
-        return vector_div(self, other)
+    # TODO: Implement operator overloading once math ops are added.
+    ...

--- a/python/shark_turbine/kernel/lang/types.py
+++ b/python/shark_turbine/kernel/lang/types.py
@@ -1,8 +1,11 @@
 from typing import Type
 
+from ..ops.math import vector_add, vector_sub, vector_mul, vector_div
+
 
 __all__ = [
     "Index",
+    "Vector",
 ]
 
 ###############################################################################
@@ -34,3 +37,17 @@ class Index(int):
     """
 
     ...
+
+
+class Vector:
+    def __add__(self, other: "Vector") -> "Vector":
+        return vector_add(self, other)
+
+    def __sub__(self, other: "Vector") -> "Vector":
+        return vector_sub(self, other)
+
+    def __mul__(self, other: "Vector") -> "Vector":
+        return vector_mul(self, other)
+
+    def __truediv__(self, other: "Vector") -> "Vector":
+        return vector_div(self, other)

--- a/python/shark_turbine/kernel/lang/types.py
+++ b/python/shark_turbine/kernel/lang/types.py
@@ -38,6 +38,7 @@ class Index(int):
 
     ...
 
+
 class Vector:
     def __add__(self, other: "Vector") -> "Vector":
         return vector_add(self, other)

--- a/python/shark_turbine/kernel/ops/__init__.py
+++ b/python/shark_turbine/kernel/ops/__init__.py
@@ -2,3 +2,4 @@ from .core import *
 from .math import *
 from .reduction import *
 from .control_flow import *
+from .memory import *

--- a/python/shark_turbine/kernel/ops/__init__.py
+++ b/python/shark_turbine/kernel/ops/__init__.py
@@ -1,1 +1,3 @@
 from .core import *
+from .math import *
+from .reduction import *

--- a/python/shark_turbine/kernel/ops/__init__.py
+++ b/python/shark_turbine/kernel/ops/__init__.py
@@ -1,3 +1,4 @@
 from .core import *
 from .math import *
 from .reduction import *
+from .control_flow import *

--- a/python/shark_turbine/kernel/ops/control_flow.py
+++ b/python/shark_turbine/kernel/ops/control_flow.py
@@ -30,4 +30,6 @@ def for_loop(
     step: Optional["Index"] = None,
     init_args: List[Any] = [],
 ) -> Callable[[Callable[["Index", List[Any]], Optional[Tuple]]], List[Any]]:
+    # TODO: The output type signature should also allow a single element return
+    # instead of a List for better programming experience.
     ...

--- a/python/shark_turbine/kernel/ops/control_flow.py
+++ b/python/shark_turbine/kernel/ops/control_flow.py
@@ -1,0 +1,22 @@
+from typing import Any, List, Tuple, Optional, Iterator, overload, Callable, Tuple, Unpack
+import typing
+
+if typing.TYPE_CHECKING:
+    from ..lang.types import Index
+
+from .base import (
+    define_op,
+)
+
+__all__ = [
+    "for_loop",
+]
+
+@define_op
+def for_loop(
+    start: "Index",
+    stop: Optional["Index"] = None,
+    step: Optional["Index"] = None,
+    init_args: List[Any] = [],
+) -> Callable[[Callable[["Index", List[Any]], Optional[Tuple]]], List[Any]]:
+    ...

--- a/python/shark_turbine/kernel/ops/control_flow.py
+++ b/python/shark_turbine/kernel/ops/control_flow.py
@@ -1,4 +1,14 @@
-from typing import Any, List, Tuple, Optional, Iterator, overload, Callable, Tuple, Unpack
+from typing import (
+    Any,
+    List,
+    Tuple,
+    Optional,
+    Iterator,
+    overload,
+    Callable,
+    Tuple,
+    Unpack,
+)
 import typing
 
 if typing.TYPE_CHECKING:
@@ -11,6 +21,7 @@ from .base import (
 __all__ = [
     "for_loop",
 ]
+
 
 @define_op
 def for_loop(

--- a/python/shark_turbine/kernel/ops/core.py
+++ b/python/shark_turbine/kernel/ops/core.py
@@ -1,8 +1,11 @@
 from typing import Any
+import typing
 
-from ..lang.types import (
-    Index,
-)
+if typing.TYPE_CHECKING:
+    from ..lang.types import (
+        Index,
+        Vector
+    )
 
 from .base import (
     define_op,
@@ -16,7 +19,7 @@ __all__ = [
 
 
 @define_op
-def kernel_buffer_getitem(kernel_buffer, key) -> Any:
+def kernel_buffer_getitem(kernel_buffer, key) -> "Vector":
     ...
 
 
@@ -26,5 +29,5 @@ def kernel_buffer_setitem(kernel_buffer, key, item) -> None:
 
 
 @define_op
-def thread_program_id() -> Index:
+def thread_program_id(axis: int) -> "Index":
     ...

--- a/python/shark_turbine/kernel/ops/core.py
+++ b/python/shark_turbine/kernel/ops/core.py
@@ -2,10 +2,7 @@ from typing import Any
 import typing
 
 if typing.TYPE_CHECKING:
-    from ..lang.types import (
-        Index,
-        Vector
-    )
+    from ..lang.types import Index, Vector
 
 from .base import (
     define_op,

--- a/python/shark_turbine/kernel/ops/math.py
+++ b/python/shark_turbine/kernel/ops/math.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple
+from typing import Tuple
 import typing
 
 if typing.TYPE_CHECKING:
@@ -8,41 +8,9 @@ from .base import (
     define_op,
 )
 
-from .._support.indexing import ElementType
-
 __all__ = [
-    "vector_add",
-    "vector_sub",
-    "vector_mul",
-    "vector_div",
-    "vector_exp",
     "vector_constant",
 ]
-
-
-@define_op
-def vector_add(lhs: "Vector", rhs: "Vector") -> "Vector":
-    ...
-
-
-@define_op
-def vector_sub(lhs: "Vector", rhs: "Vector") -> "Vector":
-    ...
-
-
-@define_op
-def vector_mul(lhs: "Vector", rhs: "Vector") -> "Vector":
-    ...
-
-
-@define_op
-def vector_div(lhs: "Vector", rhs: "Vector") -> "Vector":
-    ...
-
-
-@define_op
-def vector_exp(source: "Vector") -> "Vector":
-    ...
 
 
 @define_op

--- a/python/shark_turbine/kernel/ops/math.py
+++ b/python/shark_turbine/kernel/ops/math.py
@@ -46,7 +46,5 @@ def vector_exp(source: "Vector") -> "Vector":
 
 
 @define_op
-def vector_constant(
-    shape: Tuple[int, ...], dtype, value: int | float
-) -> "Vector":
+def vector_constant(shape: Tuple[int, ...], dtype, value: int | float) -> "Vector":
     ...

--- a/python/shark_turbine/kernel/ops/math.py
+++ b/python/shark_turbine/kernel/ops/math.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Tuple
 import typing
 
 if typing.TYPE_CHECKING:
@@ -13,7 +13,8 @@ __all__ = [
     "vector_sub",
     "vector_mul",
     "vector_div",
-    "vector_exp"
+    "vector_exp",
+    "vector_zeros"
 ]
 
 
@@ -38,4 +39,8 @@ def vector_div(lhs: "Vector", rhs: "Vector") -> "Vector":
 
 @define_op
 def vector_exp(source: "Vector") -> "Vector":
+    ...
+
+@define_op
+def vector_zeros(shape: Tuple[int, ...]) -> "Vector":
     ...

--- a/python/shark_turbine/kernel/ops/math.py
+++ b/python/shark_turbine/kernel/ops/math.py
@@ -1,0 +1,41 @@
+from typing import Any
+import typing
+
+if typing.TYPE_CHECKING:
+    from ..lang.types import Vector
+
+from .base import (
+    define_op,
+)
+
+__all__ = [
+    "vector_add",
+    "vector_sub",
+    "vector_mul",
+    "vector_div",
+    "vector_exp"
+]
+
+
+@define_op
+def vector_add(lhs: "Vector", rhs: "Vector") -> "Vector":
+    ...
+
+
+@define_op
+def vector_sub(lhs: "Vector", rhs: "Vector") -> "Vector":
+    ...
+
+
+@define_op
+def vector_mul(lhs: "Vector", rhs: "Vector") -> "Vector":
+    ...
+
+
+@define_op
+def vector_div(lhs: "Vector", rhs: "Vector") -> "Vector":
+    ...
+
+@define_op
+def vector_exp(source: "Vector") -> "Vector":
+    ...

--- a/python/shark_turbine/kernel/ops/math.py
+++ b/python/shark_turbine/kernel/ops/math.py
@@ -8,13 +8,15 @@ from .base import (
     define_op,
 )
 
+from .._support.indexing import ElementType
+
 __all__ = [
     "vector_add",
     "vector_sub",
     "vector_mul",
     "vector_div",
     "vector_exp",
-    "vector_zeros"
+    "vector_constant",
 ]
 
 
@@ -37,10 +39,14 @@ def vector_mul(lhs: "Vector", rhs: "Vector") -> "Vector":
 def vector_div(lhs: "Vector", rhs: "Vector") -> "Vector":
     ...
 
+
 @define_op
 def vector_exp(source: "Vector") -> "Vector":
     ...
 
+
 @define_op
-def vector_zeros(shape: Tuple[int, ...]) -> "Vector":
+def vector_constant(
+    shape: Tuple[int, ...], dtype, value: int | float
+) -> "Vector":
     ...

--- a/python/shark_turbine/kernel/ops/memory.py
+++ b/python/shark_turbine/kernel/ops/memory.py
@@ -1,0 +1,30 @@
+from typing import Any, List, Tuple, Optional, Iterator, overload, Callable, Tuple, Unpack
+import typing
+
+if typing.TYPE_CHECKING:
+    from ..lang.types import Index, Vector
+
+from .base import (
+    define_op,
+)
+
+__all__ = [
+    "kernel_buffer_load",
+    "kernel_buffer_store"
+]
+
+@define_op
+def kernel_buffer_load(
+    kernel_buffer,
+    multi_index: Tuple["Index", ...],
+    shape: Tuple[int, ...],
+) -> Vector:
+    ...
+
+@define_op
+def kernel_buffer_store(
+    kernel_buffer,
+    multi_index: Tuple["Index", ...],
+    item : Vector,
+) -> None:
+    ...

--- a/python/shark_turbine/kernel/ops/memory.py
+++ b/python/shark_turbine/kernel/ops/memory.py
@@ -1,4 +1,14 @@
-from typing import Any, List, Tuple, Optional, Iterator, overload, Callable, Tuple, Unpack
+from typing import (
+    Any,
+    List,
+    Tuple,
+    Optional,
+    Iterator,
+    overload,
+    Callable,
+    Tuple,
+    Unpack,
+)
 import typing
 
 if typing.TYPE_CHECKING:
@@ -8,23 +18,22 @@ from .base import (
     define_op,
 )
 
-__all__ = [
-    "kernel_buffer_load",
-    "kernel_buffer_store"
-]
+__all__ = ["kernel_buffer_load", "kernel_buffer_store"]
+
 
 @define_op
 def kernel_buffer_load(
     kernel_buffer,
     multi_index: Tuple["Index", ...],
     shape: Tuple[int, ...],
-) -> Vector:
+) -> "Vector":
     ...
+
 
 @define_op
 def kernel_buffer_store(
     kernel_buffer,
     multi_index: Tuple["Index", ...],
-    item : Vector,
+    item: "Vector",
 ) -> None:
     ...

--- a/python/shark_turbine/kernel/ops/reduction.py
+++ b/python/shark_turbine/kernel/ops/reduction.py
@@ -16,14 +16,17 @@ __all__ = [
 
 
 @define_op
-def vector_max(source: "Vector", dims: List[int]) -> "Vector":
+def vector_max(
+    source: "Vector", dims: List[int], acc) -> "Vector":
     ...
 
 
 @define_op
-def vector_sum(source: "Vector", dims: List[int]) -> "Vector":
+def vector_sum(
+    source: "Vector", dims: List[int], acc) -> "Vector":
     ...
 
+
 @define_op
-def vector_dot(lhs: "Vector", rhs: "Vector") -> "Vector":
+def vector_dot(lhs: "Vector", rhs: "Vector", acc) -> "Vector":
     ...

--- a/python/shark_turbine/kernel/ops/reduction.py
+++ b/python/shark_turbine/kernel/ops/reduction.py
@@ -9,20 +9,8 @@ from .base import (
 )
 
 __all__ = [
-    "vector_max",
-    "vector_sum",
     "vector_dot",
 ]
-
-
-@define_op
-def vector_max(source: "Vector", dims: List[int], acc) -> "Vector":
-    ...
-
-
-@define_op
-def vector_sum(source: "Vector", dims: List[int], acc) -> "Vector":
-    ...
 
 
 @define_op

--- a/python/shark_turbine/kernel/ops/reduction.py
+++ b/python/shark_turbine/kernel/ops/reduction.py
@@ -1,0 +1,24 @@
+from typing import Any, List
+import typing
+
+if typing.TYPE_CHECKING:
+    from ..lang.types import Vector
+
+from .base import (
+    define_op,
+)
+
+__all__ = [
+    "vector_max",
+    "vector_sum",
+]
+
+
+@define_op
+def vector_max(source: "Vector", dims: List[int]) -> "Vector":
+    ...
+
+
+@define_op
+def vector_sum(source: "Vector", dims: List[int]) -> "Vector":
+    ...

--- a/python/shark_turbine/kernel/ops/reduction.py
+++ b/python/shark_turbine/kernel/ops/reduction.py
@@ -11,6 +11,7 @@ from .base import (
 __all__ = [
     "vector_max",
     "vector_sum",
+    "vector_dot",
 ]
 
 
@@ -21,4 +22,8 @@ def vector_max(source: "Vector", dims: List[int]) -> "Vector":
 
 @define_op
 def vector_sum(source: "Vector", dims: List[int]) -> "Vector":
+    ...
+
+@define_op
+def vector_dot(lhs: "Vector", rhs: "Vector") -> "Vector":
     ...

--- a/python/shark_turbine/kernel/ops/reduction.py
+++ b/python/shark_turbine/kernel/ops/reduction.py
@@ -16,14 +16,12 @@ __all__ = [
 
 
 @define_op
-def vector_max(
-    source: "Vector", dims: List[int], acc) -> "Vector":
+def vector_max(source: "Vector", dims: List[int], acc) -> "Vector":
     ...
 
 
 @define_op
-def vector_sum(
-    source: "Vector", dims: List[int], acc) -> "Vector":
+def vector_sum(source: "Vector", dims: List[int], acc) -> "Vector":
     ...
 
 

--- a/tests/kernel/simple_kernel_test.py
+++ b/tests/kernel/simple_kernel_test.py
@@ -32,7 +32,7 @@ class Test(unittest.TestCase):
             i = tk.lang.program_id(0)
             out[i] = i
 
-        print(iota_kernel._trace.gm.graph)
+        print(iota_kernel._trace.region_graph)
         # Prints:
         # .graph():
         #     %out : shark_turbine.kernel.lang.types.KernelBuffer [num_users=1] = placeholder[target=out]
@@ -70,7 +70,7 @@ class Test(unittest.TestCase):
         generated = softmax(input)
         actual = torch.softmax(input, -1)
         torch.testing.assert_close(generated, actual)
-        print(softmax_kernel._trace.gm.graph)
+        print(softmax_kernel._trace.region_graph)
         # Prints:
         # graph():
         #     %input_1 : shark_turbine.kernel.lang.types.KernelBuffer [num_users=1] = placeholder[target=input]

--- a/tests/kernel/vector_codegen_test.py
+++ b/tests/kernel/vector_codegen_test.py
@@ -3,6 +3,7 @@ import unittest
 
 import torch
 import shark_turbine.kernel as tk
+import shark_turbine.kernel.lang as tkl
 
 from shark_turbine.kernel.compiler import (
     builder,
@@ -68,6 +69,112 @@ class Test(unittest.TestCase):
             sig = kernel_codegen.KernelSignature()
             sig.add_from_graph_placeholders(trace.get_root_graph())
             sig.add_grid(softmax_kernel.grid_type)
+            print(sig)
+            bound_sig, func_op = kernel_codegen.FunctionalKernelSignature.create(
+                sig, mb
+            )
+            emitter = vector_codegen.ThreadEmitter(bound_sig, trace)
+            try:
+                emitter.emit()
+            finally:
+                emitter.finish()
+                print(mb.module_op.get_asm())
+            mb.module_op.verify()
+
+    def testForLoopFx(self):
+        @tk.gen.thread(M)
+        def for_loop_kernel(
+            input: tk.lang.KernelBuffer[M, K], output: tk.lang.KernelBuffer[M, K]
+        ):
+            row_idx = tkl.program_id(0)
+            sum = input[row_idx, 0]
+            prefetch = input[row_idx, 1]
+
+            @tkl.for_loop(2, 5, init_args=[sum, prefetch])
+            def prefetch_sum(i, iter_args):
+                new_sum = iter_args[0] + iter_args[1]
+                new_prefetch = input[row_idx, i]
+                return new_sum, new_prefetch
+
+            output[row_idx, 0] = prefetch_sum[0]
+
+        trace = for_loop_kernel._trace
+        print(trace.region_graph)
+        mb = builder.ModuleBuilder()
+        with indexing.IndexingContext() as idxc:
+            idxc.bind_constant(M, 128)
+            idxc.bind_constant(K, 64)
+
+            sig = kernel_codegen.KernelSignature()
+            sig.add_from_graph_placeholders(trace.get_root_graph())
+            sig.add_grid(for_loop_kernel.grid_type)
+            print(sig)
+            bound_sig, func_op = kernel_codegen.FunctionalKernelSignature.create(
+                sig, mb
+            )
+            emitter = vector_codegen.ThreadEmitter(bound_sig, trace)
+            try:
+                emitter.emit()
+            finally:
+                emitter.finish()
+                print(mb.module_op.get_asm())
+            mb.module_op.verify()
+
+    def testGemmFx(self):
+        N = tkl.sym.N
+        M = tkl.sym.M
+        K = tkl.sym.K
+
+        GRID_N = tkl.sym.GRID_N
+        GRID_M = tkl.sym.GRID_M
+
+        def inner_gemm(
+            A: tkl.KernelBuffer[N, K],
+            B: tkl.KernelBuffer[K, M],
+            output: tkl.KernelBuffer[N, M],
+            k: int,
+            block_size: int,
+        ):
+            grid_n = tkl.program_id(0)
+            grid_m = tkl.program_id(1)
+
+            acc = tkl.constant((block_size, block_size), torch.float32, 0.0)
+
+            @tkl.for_loop(0, k // block_size, init_args=[acc])
+            def body(i, c):
+                a = tkl.load(A, (grid_n, i * block_size), (block_size, block_size))
+                b = tkl.load(B, (i * block_size, grid_m), (block_size, block_size))
+                return (tkl.dot(a, b, c),)
+
+            tkl.store(output, (grid_n, grid_m), body[0])
+
+        @tk.gen.thread(GRID_N, GRID_M)
+        def gemm_kernel(
+            A: tkl.KernelBuffer[N, K],
+            B: tkl.KernelBuffer[K, M],
+            output: tkl.KernelBuffer[N, M],
+        ):
+            # TODO: We should find a way to parameterize these so we can autotune over them.
+            # TODO: Ideally, we should be getting k from the symbol. The symbol value
+            # is currently not available at tracing time which is a problem.
+            k = 512
+            block_size = 32
+            inner_gemm(A, B, output, k, block_size)
+
+        trace = gemm_kernel._trace
+        print(trace.region_graph)
+        mb = builder.ModuleBuilder()
+        with indexing.IndexingContext() as idxc:
+            BLOCK_SIZE = 32
+            idxc.bind_constant(N, 512)
+            idxc.bind_constant(M, 512)
+            idxc.bind_constant(K, 512)
+            idxc.bind_constant(GRID_N, 512 // BLOCK_SIZE)
+            idxc.bind_constant(GRID_M, 512 // BLOCK_SIZE)
+
+            sig = kernel_codegen.KernelSignature()
+            sig.add_from_graph_placeholders(trace.get_root_graph())
+            sig.add_grid(gemm_kernel.grid_type)
             print(sig)
             bound_sig, func_op = kernel_codegen.FunctionalKernelSignature.create(
                 sig, mb


### PR DESCRIPTION
This PR supports tracing a function within a separate tracer as a "subgraph". This allows us to trace loop bodies instead of unrolling them.

Along with subgraph tracing, this patch adds several features to enable tracing a gemm kernel:

- Instead of doing slicing, add explicit tkl.load/tkl.store ops. Personally, I feel slicing may not be the way to go forward as we always have a constant sized output from the slice. If we go with slicing, we have to analyze if it's constant sized which is not worth it.
- Add support for tkl.constant, tkl.dot, tkl.for_loop.
- Add a new "Vector" class, which is a tensor like class supporting computations over it. I'm not a fan of using pytorch ops directly since I don't get control over the op signature.

I did not add support for eager executing these operations, only compile mode. All of these newly added ops can be eagerly executed, just haven't added the support in this patch.

