### PR TITLE
pin transformers for llama testing and mpmath for shark testing

### DIFF
--- a/.github/workflows/test_shark.yml
+++ b/.github/workflows/test_shark.yml
@@ -42,10 +42,11 @@ jobs:
           cd $GITHUB_WORKSPACE/SHARK
           python${{ matrix.version }} -m venv shark.venv
           source shark.venv/bin/activate
-          sed -i 's/SHARK-Turbine.git@main/SHARK-Turbine.git@${{github.sha}}/g' requirements.txt
           sed -i 's/SHARK-Turbine#/SHARK-Turbine.git@${{github.sha}}#/g' requirements.txt
           pip install -r requirements.txt --no-cache-dir
           pip install -e .
           pip uninstall -y torch
           pip install torch==2.1.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip uninstall mpmath
+          pip install mpmath==1.3.0
           python apps/shark_studio/tests/api_test.py

--- a/.github/workflows/test_shark.yml
+++ b/.github/workflows/test_shark.yml
@@ -47,6 +47,6 @@ jobs:
           pip install -e .
           pip uninstall -y torch
           pip install torch==2.1.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-          pip uninstall mpmath
+          pip uninstall -y mpmath
           pip install mpmath==1.3.0
           python apps/shark_studio/tests/api_test.py

--- a/core/pytorch-cpu-requirements.txt
+++ b/core/pytorch-cpu-requirements.txt
@@ -1,3 +1,2 @@
 --pre
 torch==2.1.0
-mpmath==1.3.0

--- a/core/pytorch-cpu-requirements.txt
+++ b/core/pytorch-cpu-requirements.txt
@@ -1,2 +1,3 @@
 --pre
 torch==2.1.0
+mpmath==1.3.0

--- a/models/requirements.txt
+++ b/models/requirements.txt
@@ -1,7 +1,7 @@
 protobuf
 sentencepiece
 shark_turbine
-transformers
+transformers==4.37.2
 accelerate
 diffusers==0.24.0
 brevitas @ git+https://github.com/Xilinx/brevitas.git@6695e8df7f6a2c7715b9ed69c4b78157376bb60b

--- a/models/requirements.txt
+++ b/models/requirements.txt
@@ -1,7 +1,7 @@
 protobuf
 sentencepiece
 shark_turbine
-transformers==4.37.2
+transformers==4.37.1
 accelerate
 diffusers==0.24.0
 brevitas @ git+https://github.com/Xilinx/brevitas.git@6695e8df7f6a2c7715b9ed69c4b78157376bb60b

--- a/models/setup.py
+++ b/models/setup.py
@@ -58,7 +58,7 @@ setup(
         "brevitas @ git+https://github.com/Xilinx/brevitas.git@6695e8df7f6a2c7715b9ed69c4b78157376bb60b",
         "protobuf",
         "sentencepiece",
-        "transformers==4.37.2",
+        "transformers==4.37.1",
         "accelerate",
         "diffusers==0.24.0",
     ],

--- a/models/setup.py
+++ b/models/setup.py
@@ -58,7 +58,7 @@ setup(
         "brevitas @ git+https://github.com/Xilinx/brevitas.git@6695e8df7f6a2c7715b9ed69c4b78157376bb60b",
         "protobuf",
         "sentencepiece",
-        "transformers",
+        "transformers==4.37.2",
         "accelerate",
         "diffusers==0.24.0",
     ],


### PR DESCRIPTION
Pin transformers to version 4.37.1 and mpmath to 1.3 to fix the testing failures with the new version until we get it fixed.
Please see #476 for details on reason for testing failure with updated transformers.