### PR TITLE
Fix README.md installation for zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Installing into a venv is highly recommended.
 
 ```
 pip install --upgrade -r core/requirements.txt
-pip install --upgrade -e core[torch-cpu-nightly,testing]
+pip install --upgrade -e "core[torch-cpu-nightly,testing]"
 ```
 
 Run tests:


### PR DESCRIPTION
zsh uses square brackets for pattern matching which means that if you need to pass literal square brackets as an argument to a command, you either need to escape them or quote the arguments.