### PR TITLE
[TK] Refactor ShapedType out of KernelBuffer and Grid

### DIFF
--- a/core/shark_turbine/kernel/_support/dtype.py
+++ b/core/shark_turbine/kernel/_support/dtype.py
@@ -17,6 +17,7 @@ _FLOAT_TYPES = ["f16", "f32", "f64"]
 _INDEX_TYPES = ["index"]
 
 
+# TODO: this should really be a type.
 class DataType:
     _name: str
     _ir_type_asm: str

--- a/core/shark_turbine/kernel/_support/regions.py
+++ b/core/shark_turbine/kernel/_support/regions.py
@@ -137,7 +137,7 @@ class SubgraphTracer(fx.Tracer):
         kwargs,
         name=None,
         type_expr=None,
-        proxy_factor_fn=None,
+        proxy_factory_fn=None,
     ):
         if self.parent is not None:
             flat_args, tree_spec = pytree.tree_flatten((args, kwargs))
@@ -154,7 +154,7 @@ class SubgraphTracer(fx.Tracer):
             kwargs,
             name,
             type_expr,
-            proxy_factor_fn,
+            proxy_factory_fn,
         )
 
         return rv

--- a/core/shark_turbine/kernel/_support/shaped_type.py
+++ b/core/shark_turbine/kernel/_support/shaped_type.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Optional, Type, TypeVar
+from typing import Optional, Type, TypeVar, cast
 
 from .dtype import DataType
 
@@ -53,7 +53,7 @@ class ShapedType(type):
         new_class = type.__new__(mcls, name, bases, dct)
         return new_class
 
-    def new_subtype(
+    def new_shaped_subtype(
         cls: Type[SubtypeT],
         *,
         symbolic_shape: SymbolicShapeExpr,
@@ -66,7 +66,7 @@ class ShapedType(type):
 
         Subtype.__name__ = cls.__name__
 
-        return Subtype
+        return cast(Type[SubtypeT], Subtype)
 
     def __str__(cls):
         return repr(cls)
@@ -107,7 +107,7 @@ class ShapedDataType(ShapedType):
         new_class = type.__new__(mcls, name, bases, dct)
         return new_class
 
-    def new_subtype(
+    def new_shaped_data_subtype(
         cls: Type[SubtypeT],
         *,
         symbolic_shape: SymbolicShapeExpr,
@@ -123,7 +123,7 @@ class ShapedDataType(ShapedType):
 
         Subtype.__name__ = cls.__name__
 
-        return Subtype
+        return cast(Type[SubtypeT], Subtype)
 
     def __str__(cls):
         return repr(cls)

--- a/core/shark_turbine/kernel/_support/shaped_type.py
+++ b/core/shark_turbine/kernel/_support/shaped_type.py
@@ -1,0 +1,136 @@
+import typing
+from typing import Optional, Type, TypeVar
+
+from .dtype import DataType
+
+if typing.TYPE_CHECKING:
+    from .indexing import IndexExpr
+
+SymbolicShapeExpr = tuple["IndexExpr", ...]
+
+SubtypeT = TypeVar("SubtypeT")
+
+###############################################################################
+# Shaped Type
+###############################################################################
+
+
+def _shaped_data_type_repr(
+    name: str,
+    *,
+    symbolic_shape: Optional[SymbolicShapeExpr],
+    dtype: Optional[DataType] = None,
+) -> str:
+    stem = name
+    if symbolic_shape:
+        stem += f"[{', '.join(repr(s) for s in symbolic_shape)}]"
+    if dtype:
+        stem += f".of({dtype})"
+    return stem
+
+
+class ShapedType(type):
+    """A shaped type.
+
+    This lets us specialize with symbolic shape information.
+    """
+
+    symbolic_shape: Optional[SymbolicShapeExpr] = None
+    rank: Optional[int]
+
+    def __new__(mcls, name: str, bases, dct):
+        symbolic_shape = dct.get("symbolic_shape")
+        if symbolic_shape is not None:
+            rank = len(symbolic_shape)
+            dct["rank"] = rank
+
+        # TODO: I don't know a better way to do this. Ask Stella for better way.
+        if "__qualname__" not in dct:
+            dct["__qualname__"] = _shaped_data_type_repr(
+                name, symbolic_shape=symbolic_shape
+            )
+
+        new_class = type.__new__(mcls, name, bases, dct)
+        return new_class
+
+    def new_subtype(
+        cls: Type[SubtypeT],
+        *,
+        symbolic_shape: SymbolicShapeExpr,
+    ) -> Type[SubtypeT]:
+        init_symbolic_shape = symbolic_shape
+
+        class Subtype(cls):
+            symbolic_shape = init_symbolic_shape
+            rank = len(init_symbolic_shape)
+
+        Subtype.__name__ = cls.__name__
+
+        return Subtype
+
+    def __str__(cls):
+        return repr(cls)
+
+    def __repr__(cls):
+        return _shaped_data_type_repr(cls.__name__, symbolic_shape=cls.symbolic_shape)
+
+
+###############################################################################
+# Shaped Data Type
+###############################################################################
+
+
+class ShapedDataType(ShapedType):
+    """A shaped type containing data of a specific element type.
+
+    This lets us specialize with symbolic shape information.
+    """
+
+    dtype: Optional[DataType] = None
+
+    def __new__(
+        mcls,
+        name: str,
+        bases,
+        dct,
+    ):
+        shaped_type = dct.get("shaped_type")
+        dtype = dct.get("dtype")
+
+        if "__qualname__" not in dct:
+            dct["__qualname__"] = _shaped_data_type_repr(
+                name,
+                symbolic_shape=shaped_type,
+                dtype=dtype,
+            )
+
+        new_class = type.__new__(mcls, name, bases, dct)
+        return new_class
+
+    def new_subtype(
+        cls: Type[SubtypeT],
+        *,
+        symbolic_shape: SymbolicShapeExpr,
+        dtype: DataType,
+    ) -> Type[SubtypeT]:
+        init_symbolic_shape = symbolic_shape
+        init_dtype = dtype
+
+        class Subtype(cls):
+            symbolic_shape = init_symbolic_shape
+            rank = len(init_symbolic_shape)
+            dtype = init_dtype
+
+        Subtype.__name__ = cls.__name__
+
+        return Subtype
+
+    def __str__(cls):
+        return repr(cls)
+
+    def __repr__(cls):
+        return _shaped_data_type_repr(
+            cls.__name__,
+            symbolic_shape=cls.symbolic_shape,
+            dtype=cls.dtype,
+        )

--- a/core/shark_turbine/kernel/_support/tracing.py
+++ b/core/shark_turbine/kernel/_support/tracing.py
@@ -24,11 +24,11 @@ from .indexing import (
     BoundedRelation,
     IndexExpr,
     IndexSymbol,
-    Grid,
-    KernelBuffer,
-    SymIndex,
     IndexingContext,
 )
+
+from ..lang.kernel_buffer import KernelBuffer
+from ..lang.grid import Grid
 
 from ..lang.types import (
     Index,

--- a/core/shark_turbine/kernel/compiler/dispatch_codegen.py
+++ b/core/shark_turbine/kernel/compiler/dispatch_codegen.py
@@ -44,7 +44,7 @@ from .kernel_codegen import (
     KernelSignature,
 )
 
-from .._support.indexing import Grid
+from ..lang.grid import Grid
 
 
 class StreamExecutable:

--- a/core/shark_turbine/kernel/compiler/kernel_codegen.py
+++ b/core/shark_turbine/kernel/compiler/kernel_codegen.py
@@ -22,13 +22,16 @@ from dataclasses import dataclass
 import torch.fx as fx
 
 from .._support.indexing import (
-    Grid,
     IndexingContext,
     IndexSymbol,
+)
+
+from ..lang.kernel_buffer import (
     KernelBuffer,
     KernelBufferUsage,
     is_kernel_buffer_meta_derived,
 )
+from ..lang.grid import Grid
 
 from .base import (
     CodegenError,
@@ -88,7 +91,7 @@ class BindingDesc:
         binding_type = self.binding_type
         if binding_type == BindingType.KERNEL_BUFFER:
             kb_t = self.kernel_buffer_type  # type: KernelBuffer
-            element_type_asm = kb_t.element_type.ir_type_asm()
+            element_type_asm = kb_t.dtype.ir_type_asm()
             symbolic_shape = kb_t.symbolic_shape
             if symbolic_shape is not None:
                 shape_asm = "x".join(sym_to_dim_asm(s) for s in kb_t.symbolic_shape)

--- a/core/shark_turbine/kernel/compiler/vector_codegen.py
+++ b/core/shark_turbine/kernel/compiler/vector_codegen.py
@@ -16,15 +16,14 @@ import torch.fx as fx
 import torch.utils._pytree as pytree
 
 from .._support.indexing import (
-    Grid,
     IndexExpr,
     IndexingContext,
-    KernelBuffer,
     IndexSymbol,
     SymIndex,
     index_expr,
-    is_kernel_buffer_meta_derived,
 )
+
+from ..lang.kernel_buffer import KernelBuffer
 
 from .._support import dtype
 

--- a/core/shark_turbine/kernel/lang/__init__.py
+++ b/core/shark_turbine/kernel/lang/__init__.py
@@ -1,15 +1,12 @@
 from .prims import *
 from .types import *
+from .kernel_buffer import *
+from .grid import *
 
 # Include publics from the _support library.
 from .._support.indexing import (
-    Grid,
-    InputBuffer,
-    KernelBuffer,
-    OutputBuffer,
     IndexExpr,
     IndexSymbol,
-    TemporaryBuffer,
     sym,
 )
 

--- a/core/shark_turbine/kernel/lang/grid.py
+++ b/core/shark_turbine/kernel/lang/grid.py
@@ -32,7 +32,7 @@ class Grid(metaclass=ShapedType):
         if not isinstance(symbolic_shape, tuple):
             symbolic_shape = (symbolic_shape,)
 
-        return cls.new_subtype(symbolic_shape=symbolic_shape)
+        return cls.new_shaped_subtype(symbolic_shape=symbolic_shape)
 
     @property
     def shape(self) -> tuple[int, ...]:

--- a/core/shark_turbine/kernel/lang/grid.py
+++ b/core/shark_turbine/kernel/lang/grid.py
@@ -1,0 +1,51 @@
+from typing import cast, Type, ClassVar
+
+from .._support.shaped_type import ShapedType
+from .._support.indexing import IndexingContext, IndexExpr
+
+__all__ = [
+    "Grid",
+]
+
+
+class Grid(metaclass=ShapedType):
+    """Grid with bounding symbolic shape information in the type."""
+
+    symbolic_shape: ClassVar[tuple[IndexExpr, ...]]
+    rank: ClassVar[int]
+    dims: list[int]
+
+    def __init__(self):
+        # Resolve the symbolic shape to concrete values.
+        idxc = IndexingContext.current()
+        if self.symbolic_shape:
+            dims = [idxc.get_static_value(dim) for dim in self.symbolic_shape]
+            if None in dims:
+                raise ValueError(f"NYI: Dynamic dims in Grid")
+            self.dims = cast(list[int], dims)
+        else:
+            self.dims = []
+
+    def __class_getitem__(
+        cls, symbolic_shape: tuple[IndexExpr, ...] | IndexExpr
+    ) -> Type["Grid"]:
+        if not isinstance(symbolic_shape, tuple):
+            symbolic_shape = (symbolic_shape,)
+
+        return cls.new_subtype(symbolic_shape=symbolic_shape)
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return tuple(self.dims)
+
+    def __repr__(self):
+        return f"{repr(type(self))}({', '.join(str(i) for i in self.dims)})"
+
+    def __getitem__(self, index: int) -> int:
+        return self.dims[index]
+
+    def __len__(self) -> int:
+        return len(self.dims)
+
+    def __iter__(self):
+        return iter(self.dims)

--- a/core/shark_turbine/kernel/lang/kernel_buffer.py
+++ b/core/shark_turbine/kernel/lang/kernel_buffer.py
@@ -1,0 +1,150 @@
+from typing import Type, TypeVar, cast, ClassVar
+
+from enum import Enum
+
+import torch
+
+from .._support.indexing import IndexExpr
+from .._support.shaped_type import ShapedDataType
+from .._support.dtype import DataType, f32
+from .. import ops
+
+__all__ = [
+    "KernelBuffer",
+    "InputBuffer",
+    "OutputBuffer",
+    "TemporaryBuffer",
+    "is_kernel_buffer_meta_derived",
+]
+
+SubtypeT = TypeVar("SubtypeT")
+
+
+class NotSetType:
+    ...
+
+
+NotSet = NotSetType()
+
+
+class KernelBufferUsage(Enum):
+    NONE = 0
+    INPUT = 1
+    OUTPUT = 2
+    TEMPORARY = 3
+
+    @staticmethod
+    def _type_name(v) -> str:
+        if v == KernelBufferUsage.NONE:
+            return "KernelBuffer"
+        elif v == KernelBufferUsage.INPUT:
+            return "InputBuffer"
+        elif v == KernelBufferUsage.OUTPUT:
+            return "OutputBuffer"
+        elif v == KernelBufferUsage.TEMPORARY:
+            return "TemporaryBuffer"
+        else:
+            raise AssertionError(f"uncovered KernelBufferUsage enum ({v})")
+
+
+class _KernelBufferMeta(ShapedDataType):
+    usage: KernelBufferUsage = KernelBufferUsage.NONE
+
+    def new_subtype(
+        cls: Type[SubtypeT],
+        *,
+        symbolic_shape: tuple[IndexExpr, ...] | NotSetType = NotSet,
+        dtype: DataType | NotSetType = NotSet,
+        usage: KernelBufferUsage | NotSetType = NotSet,
+    ) -> Type[SubtypeT]:
+        init_symbolic_shape = symbolic_shape if symbolic_shape is not NotSet else cls.symbolic_shape  # type: ignore
+        init_dtype = dtype if dtype is not NotSet else cls.dtype  # type: ignore
+        init_usage = usage if usage is not NotSet else cls.usage  # type: ignore
+
+        class SubType(cls):
+            symbolic_shape = init_symbolic_shape
+            rank = len(init_symbolic_shape)  # type: ignore
+            dtype = init_dtype
+            usage = init_usage
+
+        SubType.__name__ = KernelBufferUsage._type_name(init_usage)
+
+        return SubType
+
+
+class KernelBuffer(metaclass=_KernelBufferMeta):
+    """Represents a buffer in global memory.
+
+    Top level kernels always operate on global memory via these
+    buffers, and the primary operations that can be performed on
+    them are loads/stores and DMAs to some form of compute
+    capable local buffer.
+
+    When executing eagerly, these are backed by a normal torch
+    Tensor. When compiling, an appropriate duck-typed proxy
+    is used.
+    """
+
+    symbolic_shape: ClassVar[tuple[IndexExpr, ...]]
+    rank: ClassVar[int]
+    dtype: ClassVar[DataType]
+
+    def __init__(self, tensor: torch.Tensor):
+        assert isinstance(tensor, torch.Tensor), f"Expected Tensor but got {tensor}"
+        type_rank = type(self).rank
+        tensor_rank = len(tensor.shape)
+        if type_rank is not None and type_rank != tensor_rank:
+            raise ValueError(
+                f"Cannot create {type(self)}(tensor({tensor.shape})): mismatched symbolic rank"
+            )
+        self._tensor = tensor
+
+    def __class_getitem__(
+        cls, shape_and_dtype: tuple[IndexExpr | DataType, ...]
+    ) -> Type["KernelBuffer"]:
+        """Syntax: `KernelBuffer[shape1, shape2, ..., shapeN, dtype]`"""
+
+        if not isinstance(shape_and_dtype, tuple) or len(shape_and_dtype) < 2:
+            raise TypeError(f"Expected at least 2 arguments, got: {shape_and_dtype}")
+
+        shape = shape_and_dtype[:-1]
+        dtype = shape_and_dtype[-1]
+
+        if not all(isinstance(s, IndexExpr) for s in shape):
+            raise TypeError(f"Expected shape to be a tuple of IndexExpr, got {shape}")
+        if not isinstance(dtype, DataType):
+            raise TypeError(f"Expected dtype to be a DataType, got {dtype}")
+
+        shape = cast(tuple[IndexExpr, ...], shape)
+        dtype = cast(DataType, dtype)
+
+        return cls.new_subtype(symbolic_shape=shape, dtype=dtype)
+
+    def __repr__(self):
+        return f"{type(self)}({self._tensor})"
+
+    def __setitem__(self, key, item):
+        ops.kernel_buffer_setitem(self, key, item)
+
+    def __getitem__(self, key):
+        return ops.kernel_buffer_getitem(self, key)
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return self._tensor.shape
+
+
+class InputBuffer(KernelBuffer):
+    usage = KernelBufferUsage.INPUT
+
+
+class OutputBuffer(KernelBuffer):
+    usage = KernelBufferUsage.OUTPUT
+
+
+class TemporaryBuffer(KernelBuffer):
+    usage = KernelBufferUsage.TEMPORARY
+
+
+def is_kernel_buffer_meta_derived(t: type) -> bool:
+    return isinstance(t, _KernelBufferMeta)

--- a/core/shark_turbine/kernel/lang/kernel_buffer.py
+++ b/core/shark_turbine/kernel/lang/kernel_buffer.py
@@ -69,7 +69,7 @@ class _KernelBufferMeta(ShapedDataType):
 
         SubType.__name__ = KernelBufferUsage._type_name(init_usage)
 
-        return SubType
+        return cast(Type[SubtypeT], SubType)
 
 
 class KernelBuffer(metaclass=_KernelBufferMeta):

--- a/core/tests/kernel/arith_test.py
+++ b/core/tests/kernel/arith_test.py
@@ -14,14 +14,14 @@ from shark_turbine.kernel._support import (
     indexing,
 )
 
-M = tk.lang.sym.M
-K = tk.lang.sym.K
+M = tkl.sym.M
+K = tkl.sym.K
 
 
 class Test(unittest.TestCase):
     def testIotaFx(self):
         @tk.gen.thread(M)
-        def iota_kernel(out: tk.lang.OutputBuffer[M]):
+        def iota_kernel(out: tkl.OutputBuffer[M, tkl.f32]):
             # Integer types
             for dtype in [
                 tkl.bool,

--- a/core/tests/kernel/dispatch_codegen_test.py
+++ b/core/tests/kernel/dispatch_codegen_test.py
@@ -24,7 +24,8 @@ class Test(unittest.TestCase):
     def testEmptyStreamExecutable(self):
         @tk.gen.thread(M)
         def softmax_kernel(
-            input: tk.lang.InputBuffer[M, K], output: tk.lang.OutputBuffer[M, K]
+            input: tk.lang.InputBuffer[M, K, tkl.f32],
+            output: tk.lang.OutputBuffer[M, K, tkl.f32],
         ):
             row_index = tk.lang.program_id(0)
             input_row = input[row_index, :]

--- a/core/tests/kernel/fused_attention_test.py
+++ b/core/tests/kernel/fused_attention_test.py
@@ -18,10 +18,10 @@ class Test(unittest.TestCase):
     def testFusedAttention(self):
         @tk.gen.thread(N_CTX // BLOCK_M, BATCH * N_HEADS)
         def fused_attention(
-            Q: tkl.InputBuffer[BATCH, N_HEADS, N_CTX, D_HEAD].of(tkl.f16),
-            K: tkl.InputBuffer[BATCH, N_HEADS, N_CTX, D_HEAD].of(tkl.f16),
-            V: tkl.InputBuffer[BATCH, N_HEADS, N_CTX, D_HEAD].of(tkl.f16),
-            O: tkl.OutputBuffer[BATCH, N_HEADS, N_CTX, D_HEAD].of(tkl.f16),
+            Q: tkl.InputBuffer[BATCH, N_HEADS, N_CTX, D_HEAD, tkl.f16],
+            K: tkl.InputBuffer[BATCH, N_HEADS, N_CTX, D_HEAD, tkl.f16],
+            V: tkl.InputBuffer[BATCH, N_HEADS, N_CTX, D_HEAD, tkl.f16],
+            O: tkl.OutputBuffer[BATCH, N_HEADS, N_CTX, D_HEAD, tkl.f16],
         ):
             grid_n = tkl.program_id(0)
             grid_m = tkl.program_id(1)

--- a/core/tests/kernel/simple_kernel_test.py
+++ b/core/tests/kernel/simple_kernel_test.py
@@ -10,6 +10,7 @@ import unittest
 import torch
 
 import shark_turbine.kernel as tk
+import shark_turbine.kernel.lang as tkl
 
 M = tk.lang.sym.M
 K = tk.lang.sym.K
@@ -18,7 +19,7 @@ K = tk.lang.sym.K
 class Test(unittest.TestCase):
     def testIotaEager(self):
         @tk.gen.thread(M)
-        def iota_kernel(out: tk.lang.OutputBuffer[M]):
+        def iota_kernel(out: tk.lang.OutputBuffer[M, tkl.index]):
             i = tk.lang.program_id(0)
             out[i] = i
 
@@ -29,7 +30,7 @@ class Test(unittest.TestCase):
 
     def testIotaFx(self):
         @tk.gen.thread(M)
-        def iota_kernel(out: tk.lang.KernelBuffer[M]):
+        def iota_kernel(out: tk.lang.KernelBuffer[M, tkl.index]):
             i = tk.lang.program_id(0)
             out[i] = i
 
@@ -44,7 +45,8 @@ class Test(unittest.TestCase):
     def testSoftmax(self):
         @tk.gen.thread(M)
         def softmax_kernel(
-            input: tk.lang.InputBuffer[M, K], output: tk.lang.OutputBuffer[M, K]
+            input: tk.lang.InputBuffer[M, K, tkl.f32],
+            output: tk.lang.OutputBuffer[M, K, tkl.f32],
         ):
             row_index = tk.lang.program_id(0)
             input_row = input[row_index, :]

--- a/core/tests/kernel/vector_codegen_test.py
+++ b/core/tests/kernel/vector_codegen_test.py
@@ -14,7 +14,7 @@ class Test(unittest.TestCase):
     # API layering in place.
     def testIotaFx(self):
         @tk.gen.thread(M)
-        def iota_kernel(out: tk.lang.OutputBuffer[M]):
+        def iota_kernel(out: tk.lang.OutputBuffer[M, tkl.index]):
             i = tk.lang.program_id(0)
             secret_value = ((i * (33 - i) + 4) % 8) // 2
             out[i] = secret_value
@@ -25,7 +25,8 @@ class Test(unittest.TestCase):
     def testSoftmaxFx(self):
         @tk.gen.thread(M)
         def softmax_kernel(
-            input: tk.lang.InputBuffer[M, K], output: tk.lang.OutputBuffer[M, K]
+            input: tk.lang.InputBuffer[M, K, tkl.f32],
+            output: tk.lang.OutputBuffer[M, K, tkl.f32],
         ):
             row_index = tk.lang.program_id(0)
             input_row = input[row_index, :]
@@ -41,7 +42,8 @@ class Test(unittest.TestCase):
     def testForLoopFx(self):
         @tk.gen.thread(M)
         def for_loop_kernel(
-            input: tk.lang.InputBuffer[M, K], output: tk.lang.OutputBuffer[M, K]
+            input: tk.lang.InputBuffer[M, K, tkl.f32],
+            output: tk.lang.OutputBuffer[M, K, tkl.f32],
         ):
             row_idx = tkl.program_id(0)
             sum = input[row_idx, 0]
@@ -68,9 +70,9 @@ class Test(unittest.TestCase):
 
         @tk.gen.thread(N // BLOCK_SIZE, M // BLOCK_SIZE)
         def gemm_kernel(
-            A: tkl.InputBuffer[N, K],
-            B: tkl.InputBuffer[K, M],
-            output: tkl.OutputBuffer[N, M],
+            A: tkl.InputBuffer[N, K, tkl.f32],
+            B: tkl.InputBuffer[K, M, tkl.f32],
+            output: tkl.OutputBuffer[N, M, tkl.f32],
         ):
             grid_n = tkl.program_id(0)
             grid_m = tkl.program_id(1)


### PR DESCRIPTION
This patch moves out KernelBuffer and Grid into lang and creates a ShapedType/ShapedDataType class in _support/shaped_type which can be used elsewhere. This is in preparation for VectorType in TK.

This patch also does some other things:
 - Removes the string IndexExpr syntax for KernelBuffer/Grid, which I don't think was very useful.
  - Changes the syntax of KernelBufffer to include data type