### PR TITLE
Bump IREE to 20240226.813 and adapt to API breaks. 

### DIFF
--- a/core/iree-requirements.txt
+++ b/core/iree-requirements.txt
@@ -1,2 +1,2 @@
-iree-compiler==20240223.810
-iree-runtime==20240223.810
+iree-compiler==20240226.813
+iree-runtime==20240226.813

--- a/core/iree-requirements.txt
+++ b/core/iree-requirements.txt
@@ -1,2 +1,2 @@
-iree-compiler==20240215.802
-iree-runtime==20240215.802
+iree-compiler==20240223.810
+iree-runtime==20240223.810

--- a/core/shark_turbine/dynamo/backends/cpu.py
+++ b/core/shark_turbine/dynamo/backends/cpu.py
@@ -39,12 +39,7 @@ import torch
 from torch._dynamo.backends.common import aot_autograd
 from ..passes import turbine_cpu_pass_pipeline
 
-DEFAULT_COMPILER_FLAGS = (
-    # Enable asynchronous calling convention.
-    # TODO: Enable async execution mode.
-    # "--iree-execution-model=async-external",
-    "--iree-input-type=tm_tensor",
-)
+DEFAULT_COMPILER_FLAGS = ("--iree-input-type=torch",)
 
 
 def _base_backend(gm: torch.fx.GraphModule, example_inputs):

--- a/core/shark_turbine/dynamo/executor.py
+++ b/core/shark_turbine/dynamo/executor.py
@@ -153,7 +153,7 @@ class EagerSpecializedExecutable:
         self,
         user_module: VmModule,
         device_state: DeviceState,
-        entry_name: str = "main",
+        entry_name: str = "main$async",
     ):
         self.user_module = user_module
         self.vm_context = VmContext(

--- a/core/shark_turbine/dynamo/tensor.py
+++ b/core/shark_turbine/dynamo/tensor.py
@@ -53,11 +53,7 @@ from iree.compiler.passmanager import PassManager
 
 from ..importers.fx_importer import FxImporter
 
-DEFAULT_COMPILER_FLAGS = (
-    # Enable asynchronous calling convention.
-    "--iree-execution-model=async-external",
-    "--iree-input-type=torch",
-)
+DEFAULT_COMPILER_FLAGS = ("--iree-input-type=torch",)
 
 ###############################################################################
 # Factories and device enablement

--- a/core/tests/aot/globals_test.py
+++ b/core/tests/aot/globals_test.py
@@ -26,7 +26,7 @@ class SimpleParams(nn.Module):
         return self.classifier(x)
 
 
-class ArgsTest(unittest.TestCase):
+class GlobalsTest(unittest.TestCase):
     def testGlobalParameters(self):
         m = SimpleParams()
 


### PR DESCRIPTION
This release pulls in https://github.com/openxla/iree/pull/16486 which makes
substantial changes to torch imports:

* Always generates async code (with a special `$async` suffixed entrypoint that the default entrypoint delegates to).
* Internal structure of the generated code is different, invalidating some tests.