### PR TITLE
[TK] Add support to generate tk operations for torch.export

### DIFF
--- a/core/shark_turbine/aot/compiled_module.py
+++ b/core/shark_turbine/aot/compiled_module.py
@@ -26,6 +26,7 @@ from ..support.ir_imports import (
     PassManager,
     StringAttr,
 )
+from ..transforms.general.custom_op_expansion import ExpandCustomOpsPass
 
 from .support.procedural import (
     GlobalsDef,
@@ -51,13 +52,21 @@ __all__ = [
 
 
 class ImportPhase(enum.IntEnum):
-    # Compiles to valid MLIR that IREE can ingest as an input.
-    IMPORT = 0
+    # Imports to torch dialect IR.
+    TORCH_IR = 0
+
+    # Performs custom op expansion and post processing for known custom ops.
+    CUSTOM_OP_EXPANSION = 1
+
+    # Compiles to valid MLIR that IREE can ingest as an input with the
+    # input-type of torch.
+    IMPORT = CUSTOM_OP_EXPANSION
+
     # Runs the IREE input pipeline to compile to internal form.
-    INPUT = 1
+    IREE_INTERNAL = 2
 
     # The full import pipeline (this is an alias for another enum value).
-    FULL = 1
+    FULL = IREE_INTERNAL
 
     @staticmethod
     def parse(spec: Union[str, None, "ImportPhase"]) -> "ImportPhase":
@@ -259,7 +268,7 @@ class CompiledModuleInstanceInfo:
         # The shadow dict holds instance attributes. We stash them here and the
         # Program instance itself arbitrates access via getattr/setattr.
         self.shadow_dict = dict()
-        self.current_import_phase = ImportPhase.IMPORT
+        self.current_import_phase = ImportPhase.TORCH_IR
 
 
 ################################################################################
@@ -294,6 +303,7 @@ def _uncallable_public_export(*args, **kwargs):
 
 
 _COMPILED_MODULE_API_ATTRIBUTES = [
+    "expand_custom_ops",
     "export_global",
     "get_class_info",
     "get_info",
@@ -398,23 +408,39 @@ class CompiledModule(metaclass=CompiledModuleMeta):
 
     @staticmethod
     def run_import(
-        inst: "CompiledModule", import_to: Union[ImportPhase, str, None] = "full"
+        inst: "CompiledModule", import_to: Union[ImportPhase, str, None] = "import"
     ):
         import_to = ImportPhase.parse(import_to)
         info = CompiledModule.get_info(inst)
-        if info.current_import_phase >= import_to:
-            return
-
-        for phase in [ImportPhase.IMPORT, ImportPhase.INPUT]:
+        for phase in [
+            ImportPhase.TORCH_IR,
+            ImportPhase.CUSTOM_OP_EXPANSION,
+            ImportPhase.IREE_INTERNAL,
+        ]:
+            if phase > import_to:
+                logger.debug("Stopped import at phase %s", info.current_import_phase)
+                break
             if info.current_import_phase >= phase:
                 continue
             logger.debug("Run import phase %s", phase)
-            if phase == ImportPhase.IMPORT:
+            if phase == ImportPhase.TORCH_IR:
+                # Starting phase. Do nothing.
                 ...
-            if phase == ImportPhase.INPUT:
+            elif phase == ImportPhase.CUSTOM_OP_EXPANSION:
+                CompiledModule.expand_custom_ops(inst)
+            elif phase == ImportPhase.IREE_INTERNAL:
                 CompiledModule.run_pass_pipeline(inst, "builtin.module(torch-to-iree)")
             else:
                 assert False, f"Phase {phase} not handled in switch"
+            info.current_import_phase = phase
+
+    @staticmethod
+    def expand_custom_ops(inst: "CompiledModule"):
+        """Performs custom torch.operator expansion for known custom ops."""
+        logger.debug("Expand known torch.operator custom ops")
+        module_op = CompiledModule.get_mlir_module(inst)
+        p = ExpandCustomOpsPass(module_op)
+        p.run()
 
     @staticmethod
     def run_pass_pipeline(
@@ -483,7 +509,7 @@ class CompiledModule(metaclass=CompiledModuleMeta):
         *,
         context: Optional[Context] = None,
         module_op: Optional[Operation] = None,
-        import_to: Union[ImportPhase, None, str] = "full",
+        import_to: Union[ImportPhase, None, str] = "import",
     ):
         import_to = ImportPhase.parse(import_to)
         self = super().__new__(cls)

--- a/core/shark_turbine/aot/exporter.py
+++ b/core/shark_turbine/aot/exporter.py
@@ -13,7 +13,6 @@ import platform
 import torch
 
 from iree.compiler.api import (
-    Invocation,
     Session,
     Source,
     Output,
@@ -29,6 +28,7 @@ from .compiled_module import (
     CompiledModule,
     CompiledModuleMeta,
     ExportProcDef,
+    ImportPhase,
 )
 from .support.procedural import (
     AbstractTypedef,
@@ -81,8 +81,12 @@ class ExportOutput:
             else:
                 self.mlir_module.print(file=f, binary=True)
 
-    def _run_import(self):
-        CompiledModule.run_import(self.compiled_module)
+    def import_to(self, import_to: Union[ImportPhase, str]):
+        """Compiles the modules to a mnemonic import phase.
+
+        This is a no-op if already compiled to this phase.
+        """
+        CompiledModule.run_import(self.compiled_module, import_to)
 
     def compile(
         self,

--- a/core/shark_turbine/kernel/_support/tracing.py
+++ b/core/shark_turbine/kernel/_support/tracing.py
@@ -1,25 +1,18 @@
 from abc import ABC, abstractmethod
-import typing
 from typing import (
     Optional,
     TypeVar,
     Callable,
     Type,
     cast,
-    List,
     Dict,
     Tuple,
-    Any,
 )
 
-if typing.TYPE_CHECKING:
-    from ..compiler.ir import Operation
+from ..compiler.ir import Operation
 
 import functools
 import warnings
-import contextlib
-import torch.utils._pytree as pytree
-import random
 
 import torch.fx as fx
 
@@ -36,7 +29,6 @@ from ..lang.grid import Grid
 
 from ..lang.types import (
     Index,
-    Vector,
 )
 
 from .regions import RegionGraph, SubgraphTracer
@@ -458,10 +450,10 @@ class TestLaunchContext(LaunchContext):
 
 
 class AOTLaunchContext(LaunchContext):
-    module: "Operation"
+    module: Operation
 
     def __init__(
-        self, module: "Operation", constant_bindings: Dict[IndexSymbol, int] = {}
+        self, module: Operation, constant_bindings: Dict[IndexSymbol, int] = {}
     ):
         self.module = module
         super().__init__(constant_bindings)

--- a/core/shark_turbine/kernel/_support/tracing.py
+++ b/core/shark_turbine/kernel/_support/tracing.py
@@ -456,10 +456,13 @@ class TestLaunchContext(LaunchContext):
     def launch(self, launchable: Launchable, args, kwargs):
         return launchable.test_execute(args, kwargs)
 
+
 class AOTLaunchContext(LaunchContext):
     module: "Operation"
 
-    def __init__(self, module: "Operation", constant_bindings: Dict[IndexSymbol, int] = {}):
+    def __init__(
+        self, module: "Operation", constant_bindings: Dict[IndexSymbol, int] = {}
+    ):
         self.module = module
         super().__init__(constant_bindings)
 

--- a/core/shark_turbine/kernel/gen/__init__.py
+++ b/core/shark_turbine/kernel/gen/__init__.py
@@ -1,3 +1,4 @@
 from .thread import *
+from .kernel import *
 
 from .._support.tracing import TestLaunchContext

--- a/core/shark_turbine/kernel/gen/kernel.py
+++ b/core/shark_turbine/kernel/gen/kernel.py
@@ -1,0 +1,140 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Custom op registeration for TK"""
+
+import inspect
+
+import torch
+
+from typing import (
+    Type,
+    Callable,
+    Any
+)
+
+from ..lang.kernel_buffer import is_kernel_buffer_meta_derived
+
+from ..lang import (
+    KernelBuffer,
+    InputBuffer,
+    OutputBuffer,
+    Grid,
+    IndexExpr,
+)
+
+from .thread import LaunchableThread
+
+from ..compiler.ir import StringAttr, SymbolRefAttr, ArrayAttr, flow_d, IrType, Value
+
+from ...runtime.op_reg import (
+    CustomOp,
+    KernelBuilder,
+    KernelSelection,
+    def_library,
+    TensorArg,
+)
+
+from .._support.tracing import AOTLaunchContext
+from .._support.indexing import IndexingContext
+
+TK_LIBRARY = def_library("tk")
+
+def kernel(*symbolic_shape: IndexExpr):
+
+    def decorator(f: Callable):
+        # Convert all InputBuffer to inputs and OutputBuffers to outputs
+        sig = inspect.signature(f)
+        params = sig.parameters
+        inputs : list[tuple[str, Any]] = []
+        outputs : list[tuple[str, Any]] = []
+        for arg_name, param in params.items():
+            # TODO: Implement more input arguements.
+            if not is_kernel_buffer_meta_derived(param.annotation):
+                raise NotImplementedError("Only KernelBuffer is supported as input for now")
+
+            if param.annotation.usage == InputBuffer.usage:
+                inputs.append((arg_name, param.annotation))
+            elif param.annotation.usage == OutputBuffer.usage:
+                outputs.append((arg_name, param.annotation))
+
+        name = f.__name__
+        input_signature = ["Tensor " + name for name, _ in inputs]
+        output_signature = ["Tensor " + name for name, _ in outputs]
+
+        @CustomOp.register(library=TK_LIBRARY)
+        class TKCustomOp(CustomOp):
+            signature = f"{name}({', '.join(input_signature)}) -> ({', '.join(output_signature)})"
+
+            def select(self, ksel: KernelSelection):
+                # Infer the result tensor based on the input tensor
+                idxc = IndexingContext()
+
+                i = 0
+                for arg_name, arg in inputs:
+                    if is_kernel_buffer_meta_derived(arg):
+                        x = ksel.arg_tensor(i)
+                        # We currently only do static dimensions.
+                        # TODO: Support dynamic dimensions.
+                        x.spec_dims = list(x.t.shape)
+                        assert isinstance(x, TensorArg)
+                        idxc.bind_shaped(arg_name, arg, list(x.t.shape))
+                        i += 1
+                    else:
+                        raise NotImplementedError("Only KernelBuffer is supported as input for now")
+
+                idxc.finalize()
+
+                i = 0
+                for _, arg in outputs:
+                    if is_kernel_buffer_meta_derived(arg):
+                        shape = arg.symbolic_shape
+                        static_shape = [idxc.get_static_value(x) for x in shape]
+                        x = torch.empty(*static_shape)
+                        ksel.return_tensor(x)
+                        # TODO: Support dynamic dimensions.
+                        # Set spec_dims for output so that we can infer the
+                        # type of the output tensor.
+                        ksel.result_descs[i].spec_dims = list(x.shape)
+                        i += 1
+                    else:
+                        raise NotImplementedError("Only KernelBuffer is supported as input for now")
+
+            def generate(self, ksel: KernelSelection, kb: KernelBuilder):
+                entrypoint = "tk_kernel_" + name
+                # Create a flow.dispatch op to the kernel
+                dispatch = SymbolRefAttr.get([entrypoint, entrypoint])
+                entrypoints = ArrayAttr.get([dispatch])
+
+                result_types = [IrType.parse(x.mlir_type_asm) for x in ksel.result_descs]
+
+                out = flow_d.DispatchOp(
+                    result_types, [], entrypoints, kb.arg_bindings, [], []
+                )
+
+                kb.yield_results(*out.results_)
+
+                # Build the kernel as a stream executable.
+                args = []
+                for arg in ksel.arg_descs:
+                    if isinstance(arg, TensorArg):
+                        args.append(arg.t)
+                    else:
+                        raise NotImplementedError("Non TensorArg arg binding")
+
+                for res in ksel.result_descs:
+                    if isinstance(res, TensorArg):
+                        args.append(res.t)
+                    else:
+                        raise NotImplementedError("Non TensorArg result binding")
+
+                launchable = LaunchableThread(Grid[symbolic_shape], entrypoint, f)
+                with AOTLaunchContext(kb.module_body.owner) as launch_ctx:
+                    launch_ctx.launch(launchable, args, {})
+
+        return TKCustomOp
+    
+    return decorator

--- a/core/shark_turbine/kernel/gen/kernel.py
+++ b/core/shark_turbine/kernel/gen/kernel.py
@@ -10,11 +10,7 @@ import inspect
 
 import torch
 
-from typing import (
-    Type,
-    Callable,
-    Any
-)
+from typing import Type, Callable, Any
 
 from ..lang.kernel_buffer import is_kernel_buffer_meta_derived
 
@@ -43,18 +39,20 @@ from .._support.indexing import IndexingContext
 
 TK_LIBRARY = def_library("tk")
 
-def kernel(*symbolic_shape: IndexExpr):
 
+def kernel(*symbolic_shape: IndexExpr):
     def decorator(f: Callable):
         # Convert all InputBuffer to inputs and OutputBuffers to outputs
         sig = inspect.signature(f)
         params = sig.parameters
-        inputs : list[tuple[str, Any]] = []
-        outputs : list[tuple[str, Any]] = []
+        inputs: list[tuple[str, Any]] = []
+        outputs: list[tuple[str, Any]] = []
         for arg_name, param in params.items():
             # TODO: Implement more input arguements.
             if not is_kernel_buffer_meta_derived(param.annotation):
-                raise NotImplementedError("Only KernelBuffer is supported as input for now")
+                raise NotImplementedError(
+                    "Only KernelBuffer is supported as input for now"
+                )
 
             if param.annotation.usage == InputBuffer.usage:
                 inputs.append((arg_name, param.annotation))
@@ -84,7 +82,9 @@ def kernel(*symbolic_shape: IndexExpr):
                         idxc.bind_shaped(arg_name, arg, list(x.t.shape))
                         i += 1
                     else:
-                        raise NotImplementedError("Only KernelBuffer is supported as input for now")
+                        raise NotImplementedError(
+                            "Only KernelBuffer is supported as input for now"
+                        )
 
                 idxc.finalize()
 
@@ -101,7 +101,9 @@ def kernel(*symbolic_shape: IndexExpr):
                         ksel.result_descs[i].spec_dims = list(x.shape)
                         i += 1
                     else:
-                        raise NotImplementedError("Only KernelBuffer is supported as input for now")
+                        raise NotImplementedError(
+                            "Only KernelBuffer is supported as input for now"
+                        )
 
             def generate(self, ksel: KernelSelection, kb: KernelBuilder):
                 entrypoint = "tk_kernel_" + name
@@ -109,7 +111,9 @@ def kernel(*symbolic_shape: IndexExpr):
                 dispatch = SymbolRefAttr.get([entrypoint, entrypoint])
                 entrypoints = ArrayAttr.get([dispatch])
 
-                result_types = [IrType.parse(x.mlir_type_asm) for x in ksel.result_descs]
+                result_types = [
+                    IrType.parse(x.mlir_type_asm) for x in ksel.result_descs
+                ]
 
                 out = flow_d.DispatchOp(
                     result_types, [], entrypoints, kb.arg_bindings, [], []
@@ -136,5 +140,5 @@ def kernel(*symbolic_shape: IndexExpr):
                     launch_ctx.launch(launchable, args, {})
 
         return TKCustomOp
-    
+
     return decorator

--- a/core/shark_turbine/kernel/gen/thread.py
+++ b/core/shark_turbine/kernel/gen/thread.py
@@ -1,6 +1,7 @@
 from typing import (
     Type,
     Callable,
+    Optional,
 )
 
 import inspect
@@ -20,6 +21,8 @@ from .._support.tracing import (
     EagerContext,
     Launchable,
     KernelRegionGraph,
+    LaunchContext,
+    AOTLaunchContext,
 )
 
 from .._support.indexing import IndexingContext
@@ -30,6 +33,11 @@ from ..compiler import (
     builder,
     vector_codegen,
     host_codegen,
+)
+
+from ..compiler.ir import (
+    Context,
+    Operation,
 )
 
 __all__ = [
@@ -93,7 +101,7 @@ class LaunchableThread(Launchable):
                 current_thread[-1] = it
                 self._eager_function(*bound.args, **bound.kwargs)
 
-    def test_execute(self, args, kwargs):
+    def _trace_and_get_kernel_signature(self, args, kwargs, context: Optional[Context] = None, module_op: Optional[Operation] = None):
         # Trace the function.
         trace = self._trace()
         idxc = IndexingContext.current()
@@ -118,9 +126,9 @@ class LaunchableThread(Launchable):
 
         grid = self.grid_type()
 
-        mb = builder.ModuleBuilder()
-        exe = dispatch_codegen.StreamExecutable(mb)
+        mb = builder.ModuleBuilder(context=context, module_op=module_op)
         entrypoint_name = self._name
+        exe = dispatch_codegen.StreamExecutable(mb, name=entrypoint_name)
         dispatch_entrypoint = exe.define_entrypoint(entrypoint_name, kernel_sig, grid)
         emitter = vector_codegen.ThreadEmitter(dispatch_entrypoint, trace)
         emitter.emit()
@@ -128,9 +136,25 @@ class LaunchableThread(Launchable):
 
         mb.module_op.verify()
 
+        return mb, exe, kernel_sig, entrypoint_name
+
+    def test_execute(self, args, kwargs):
+        mb, exe, kernel_sig, entrypoint_name = self._trace_and_get_kernel_signature(
+            args, kwargs
+        )
         host_codegen.isolated_test_call(mb, exe, kernel_sig, entrypoint_name)
 
         print(mb.module_op.get_asm())
+
+    def aot_execute(self, args, kwargs):
+        launch_context = LaunchContext.current()
+        assert isinstance(launch_context, AOTLaunchContext)
+
+        module = launch_context.module
+
+        mb, exe, kernel_sig, entrypoint_name = self._trace_and_get_kernel_signature(
+            args, kwargs, context=module.context, module_op=module.operation
+        )
 
     def __repr__(self):
         return f"tk.gen.thread @{self._name}[{self.grid_type}]"

--- a/core/shark_turbine/kernel/gen/thread.py
+++ b/core/shark_turbine/kernel/gen/thread.py
@@ -101,7 +101,13 @@ class LaunchableThread(Launchable):
                 current_thread[-1] = it
                 self._eager_function(*bound.args, **bound.kwargs)
 
-    def _trace_and_get_kernel_signature(self, args, kwargs, context: Optional[Context] = None, module_op: Optional[Operation] = None):
+    def _trace_and_get_kernel_signature(
+        self,
+        args,
+        kwargs,
+        context: Optional[Context] = None,
+        module_op: Optional[Operation] = None,
+    ):
         # Trace the function.
         trace = self._trace()
         idxc = IndexingContext.current()

--- a/core/shark_turbine/runtime/op_reg/base.py
+++ b/core/shark_turbine/runtime/op_reg/base.py
@@ -745,7 +745,7 @@ def _get_meta_impl(op: CustomOp):
         op.select(sel)
         if logger.isEnabledFor(logging.DEBUG):
             logging.debug(
-                "Meta dispatch on %s for specialization %s", op.name, sel.spec_key
+                "Meta dispatch on %s for specialization %s", op.signature, sel.spec_key
             )
         return sel.generate_meta_returns()
 

--- a/core/tests/aot/args_test.py
+++ b/core/tests/aot/args_test.py
@@ -20,7 +20,7 @@ class ArgsTest(unittest.TestCase):
             def foobar(self, a=AbstractTensor(3, 2), b=AbstractTensor(1, 1)):
                 return b, a
 
-        inst = ProcArgsModule(context=Context())
+        inst = ProcArgsModule(context=Context(), import_to="full")
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
@@ -37,7 +37,7 @@ class ArgsTest(unittest.TestCase):
             def compute(a, b):
                 return a + b
 
-        inst = testProcToJitArgs(context=Context())
+        inst = testProcToJitArgs(context=Context(), import_to="full")
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
@@ -56,7 +56,7 @@ class ArgsTest(unittest.TestCase):
             def compute(a, b):
                 return a + b
 
-        inst = ProcArgsModule(context=Context())
+        inst = ProcArgsModule(context=Context(), import_to="full")
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertEqual(

--- a/core/tests/aot/globals_test.py
+++ b/core/tests/aot/globals_test.py
@@ -215,7 +215,7 @@ class GlobalsTest(unittest.TestCase):
             def read(self):
                 return self.state_index
 
-        inst = DerivedState(context=Context())
+        inst = DerivedState(context=Context(), import_to="full")
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn("@_state_index.global {noinline} = 0 : index", module_str)

--- a/core/tests/aot/jittable_test.py
+++ b/core/tests/aot/jittable_test.py
@@ -35,7 +35,7 @@ class JittableTests(unittest.TestCase):
         self.assertIn(
             "func private @compute() -> !torch.vtensor<[2,2],f32>", module_str
         )
-        CompiledModule.run_import(inst)
+        CompiledModule.run_import(inst, import_to="full")
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertNotIn("!torch.vtensor", module_str)

--- a/core/tests/kernel/aot_kernel_test.py
+++ b/core/tests/kernel/aot_kernel_test.py
@@ -1,0 +1,74 @@
+# Copyright 2024 Nod Labs, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import re
+import unittest
+
+import torch
+from shark_turbine.aot import export
+import shark_turbine.kernel as tk
+import shark_turbine.kernel.lang as tkl
+
+
+def export_softmax_kernel():
+    M = tkl.sym.M
+    N = tkl.sym.K
+
+    @tk.gen.kernel(M)
+    def softmax(
+        input: tkl.InputBuffer[M, N, tkl.f16], output: tkl.OutputBuffer[M, N, tkl.f16]
+    ):
+        row_index = tkl.program_id(0)
+        row = tkl.load(input, (row_index, 0), (1, N))
+        row_minus_max = row - tkl.max(row)
+        numerator = tkl.exp2(row_minus_max)
+        denominator = tkl.sum(numerator)
+        softmax_output = numerator / denominator
+        tkl.store(output, (row_index, 0), softmax_output)
+
+    class NN(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(64, 64, dtype=torch.float16)
+
+        def forward(self, x):
+            x = self.linear(x)
+            x = softmax(x)
+            return x
+
+    model = NN()
+    a = torch.ones(64, 64, dtype=torch.float16)
+    exported = export(model, a)
+    return exported
+
+
+class AotKernelTest(unittest.TestCase):
+    def test_unique_naming(self):
+        # We test it twice to ensure that local name collisions cannot happen,
+        # verifying that each run generates a uniquely named kernel. This is
+        # a by-product of the Torch namespace being global and every one of
+        # these that we define being a separate incarnation based on the
+        # same local function name.
+        unique_names = set()
+        for _ in range(2):
+            exported = export_softmax_kernel()
+            exported.print_readable()
+            ir_text = str(exported.mlir_module)
+            matches = re.findall(
+                r"flow.dispatch @(tk_kernel_softmax__([0-9]+))::", ir_text
+            )
+            self.assertEqual(1, len(matches))
+            match = matches[0]
+            print("NAME MATCH:", match)
+            self.assertNotIn(match, unique_names)
+            unique_names.add(match)
+
+
+if __name__ == "__main__":
+    import logging
+
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()


### PR DESCRIPTION
* Adds `tkl.gen.kernel` decorator to generate a registered/callable kernel.
* The kernel can be used in both AOT and eager contexts.
* Adds some support to kernel registration for uniqueing names like these that are not user-facing and can be defined multiple times.
* Changes the CompiledModule phasing to include a custom op expansion phase. Also defaults it to `IMPORT` instead of `FULL` in a couple of low level places where it still had the old default. This is now consistent with expected, canonical usage but still allows importing to IREE's internal IR if desired (i.e. `FULL`).