### PR TITLE
[models] Implement KV-cache to have own global for each layer, K, V.

### DIFF
--- a/models/turbine_models/custom_models/stateless_llama.py
+++ b/models/turbine_models/custom_models/stateless_llama.py
@@ -154,6 +154,9 @@ def export_transformer_model(
         size=(BATCH_SIZE, MAX_STEP_SEQ, HEADS, HIDDEN_DIM),
         dtype=dtype,
     )
+    kv_cache_structure = {
+        "layer_idx": [abstractify(global_pkv) for _ in range(NUM_LAYERS)],
+    }
 
     mapper = {}
     if external_weights is not None:
@@ -167,10 +170,6 @@ def export_transformer_model(
         elif external_weights == "gguf":
             tensor_mapper = remap_gguf.TensorNameMap(remap_gguf.MODEL_ARCH.LLAMA, HEADS)
             mapper = tensor_mapper.mapping
-
-    kv_cache_structure = {
-        "layer_idx": [abstractify(global_pkv) for _ in range(NUM_LAYERS)],
-    }
 
     class StateUpdateModule(CompiledModule):
         if external_weights:

--- a/models/turbine_models/custom_models/stateless_llama.py
+++ b/models/turbine_models/custom_models/stateless_llama.py
@@ -396,6 +396,7 @@ def export_transformer_model(
         inst = StreamingStateUpdateModule(context=Context(), import_to=import_to)
     else:
         inst = StateUpdateModule(context=Context(), import_to=import_to)
+    del mod
     # TODO: Integrate with external parameters to actually be able to run
     # TODO: Make more generalizable to be able to quantize with all  compile_to options
     if quantization == "int4" and not compile_to == "linalg":

--- a/models/turbine_models/custom_models/stateless_llama.py
+++ b/models/turbine_models/custom_models/stateless_llama.py
@@ -396,7 +396,6 @@ def export_transformer_model(
         inst = StreamingStateUpdateModule(context=Context(), import_to=import_to)
     else:
         inst = StateUpdateModule(context=Context(), import_to=import_to)
-    del mod
     # TODO: Integrate with external parameters to actually be able to run
     # TODO: Make more generalizable to be able to quantize with all  compile_to options
     if quantization == "int4" and not compile_to == "linalg":

--- a/models/turbine_models/custom_models/stateless_llama.py
+++ b/models/turbine_models/custom_models/stateless_llama.py
@@ -180,7 +180,9 @@ def export_transformer_model(
         else:
             params = export_parameters(mod)
         global_seq_step = export_global(AbstractIndex, mutable=True)
-        global_k_caches = export_global_tree(kv_cache_structure, mutable=True)
+        global_k_caches = export_global_tree(
+            kv_cache_structure, uninitialized=True, mutable=True
+        )
         global_v_caches = export_global_tree(
             kv_cache_structure, uninitialized=True, mutable=True
         )


### PR DESCRIPTION
In this implementation, we are splitting up the KV cache to have a global for each layer for each K/V. This will allow for cleaner indexing which will lead to simpler analysis and better perf down the line.

One analysis that we need this for is to check that we have independent reads and writes to KV-cache. We need this to remove redundant copies of KV-cache.  We can also do the same with integrated/big slab but would be much harder since it will require us to analyze dynamic striding and more complex ranges.