### PR TITLE
Stateless llama testing + SDXL CI Job

### DIFF
--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run stateless_llama tests
         run: |
-          pytest models/turbine_models/tests/stateless_llama_test.py -s -v
+          pytest models/turbine_models/tests/stateless_llama_test.py -s
 
       - name: Run sd tests
         run: |

--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        os: [nodai-amdgpu-w7900-x86-64]
+        os: [nodai-ubuntu-builder-large]
 
     runs-on: ${{matrix.os}}
     steps:
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run stateless_llama tests
         run: |
-          pytest models/turbine_models/tests/stateless_llama_test.py
+          pytest models/turbine_models/tests/stateless_llama_test.py -s -v
 
       - name: Run sd tests
         run: |

--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        os: [nodai-ubuntu-builder-large]
+        os: [nodai-amdgpu-w7900-x86-64]
 
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run stateless_llama tests
         run: |
-          pytest models/turbine_models/tests/stateless_llama_test.py -v
+          pytest models/turbine_models/tests/stateless_llama_test.py
 
       - name: Run sd tests
         run: |

--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        os: [nodai-amdgpu-w7900-x86-64]
+        os: [nodai-ubuntu-builder-large]
 
     runs-on: ${{matrix.os}}
     steps:
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run stateless_llama tests
         run: |
-          pytest models/turbine_models/tests/stateless_llama_test.py -s
+          pytest models/turbine_models/tests/stateless_llama_test.py -v
 
       - name: Run sd tests
         run: |

--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        os: [nodai-amdgpu-w7900-x86-64]
+        os: [nodai-ubuntu-builder-large]
 
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/test_sdxl.yml
+++ b/.github/workflows/test_sdxl.yml
@@ -2,6 +2,7 @@ name: SD/SDXL Models Nightly
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
     - cron:  '30 6 * * *'
 

--- a/.github/workflows/test_sdxl.yml
+++ b/.github/workflows/test_sdxl.yml
@@ -1,22 +1,12 @@
-name: Test Turbine Models
+name: SD/SDXL Models Nightly
 
 on:
   workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - main
-
-concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit). The workflow name is prepended to avoid conflicts between
-  # different workflows.
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
+  schedule:
+    - cron:  '30 6 * * *'
 
 jobs:
-  test-turbine-models:
+  test-sdxl-models:
     strategy:
       matrix:
         version: [3.11]
@@ -31,8 +21,11 @@ jobs:
 
       - name: "Checkout Code"
         uses: actions/checkout@v2
+        with:
+          ref: ean-sd-fp16
 
       - name: Sync source deps
+        # build IREE from source with -DIREE_BUILD_TRACY=ON if getting tracy profile
         run: |
           python -m pip install --upgrade pip
           # Note: We install in three steps in order to satisfy requirements
@@ -42,17 +35,18 @@ jobs:
             -r core/pytorch-cpu-requirements.txt \
             -r core/torchvision-requirements.txt          
           pip install --upgrade -r core/requirements.txt
-          pip install -e core[testing]
+          pip install -e core[testing,torch-cpu-nightly]
+          pip install --upgrade -r models/requirements.txt
           pip install -e models
       
       - name: Show current free memory
         run: |
           free -mh
 
-      - name: Run stateless_llama tests
+      - name: Run sd/sdxl tests
         run: |
-          pytest models/turbine_models/tests/stateless_llama_test.py -v
-
-      - name: Run sd tests
-        run: |
+          pip install --upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
           pytest models/turbine_models/tests/sd_test.py
+          pytest models/turbine_models/tests/sdxl_test.py --device cpu --rt_device local-task --iree_target_triple x86_64-linux-gnu
+          pytest models/turbine_models/tests/sdxl_test.py --device vulkan --rt_device vulkan --iree_target_triple rdna3-unknown-linux
+          pytest models/turbine_models/tests/sdxl_test.py --device rocm --rt_device rocm --iree_target_triple gfx90a

--- a/.github/workflows/test_sdxl.yml
+++ b/.github/workflows/test_sdxl.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Run sd/sdxl tests
         run: |
           pip install --upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
-          pytest models/turbine_models/tests/sd_test.py
           pytest models/turbine_models/tests/sdxl_test.py --device cpu --rt_device local-task --iree_target_triple x86_64-linux-gnu
           pytest models/turbine_models/tests/sdxl_test.py --device vulkan --rt_device vulkan --iree_target_triple rdna3-unknown-linux
           pytest models/turbine_models/tests/sdxl_test.py --device rocm --rt_device rocm --iree_target_triple gfx90a

--- a/.github/workflows/test_sdxl.yml
+++ b/.github/workflows/test_sdxl.yml
@@ -1,7 +1,6 @@
 name: SDXL Models Nightly
 
 on:
-  workflow_dispatch:
   pull_request:
   schedule:
     - cron:  '30 6 * * *'

--- a/.github/workflows/test_sdxl.yml
+++ b/.github/workflows/test_sdxl.yml
@@ -1,4 +1,4 @@
-name: SD/SDXL Models Nightly
+name: SDXL Models Nightly
 
 on:
   workflow_dispatch:
@@ -44,7 +44,7 @@ jobs:
         run: |
           free -mh
 
-      - name: Run sd/sdxl tests
+      - name: Run sdxl tests
         run: |
           pip install --upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
           pytest models/turbine_models/tests/sdxl_test.py --device cpu --rt_device local-task --iree_target_triple x86_64-linux-gnu

--- a/.github/workflows/test_sdxl.yml
+++ b/.github/workflows/test_sdxl.yml
@@ -1,7 +1,6 @@
 name: SDXL Models Nightly
 
 on:
-  pull_request:
   schedule:
     - cron:  '30 6 * * *'
 

--- a/models/turbine_models/custom_models/llm_runner.py
+++ b/models/turbine_models/custom_models/llm_runner.py
@@ -169,7 +169,6 @@ def run_llm(
     chat_mode=False,
     chat_sys_prompt=DEFAULT_CHAT_SYS_PROMPT,
 ):
-    print("STARTING RUN LLM")
     tokenizer = AutoTokenizer.from_pretrained(
         hf_model_name,
         use_fast=False,
@@ -181,7 +180,6 @@ def run_llm(
         external_weight_path=external_weight_path,
         streaming_llm=streaming_llm,
     )
-    print("INITIALIZATION COMPLETE")
     if not chat_mode:
         prompt = append_user_prompt(chat_sys_prompt, prompt)
         initial_input = tokenizer(prompt, return_tensors="pt")

--- a/models/turbine_models/custom_models/llm_runner.py
+++ b/models/turbine_models/custom_models/llm_runner.py
@@ -204,17 +204,31 @@ def run_torch_llm(
     prompt,
     streaming_llm=False,
     chat_sys_prompt=DEFAULT_CHAT_SYS_PROMPT,
+    model=None,
+    tokenizer=None,
 ):
     from turbine_models.model_builder import HFTransformerBuilder
     from transformers import AutoModelForCausalLM
 
-    model_builder = HFTransformerBuilder(
-        example_input=None,
-        hf_id=hf_model_name,
-        auto_model=AutoModelForCausalLM,
-        hf_auth_token=hf_auth_token,
-        auto_tokenizer=AutoTokenizer,
-    )
+    if model == None:
+        model_builder = HFTransformerBuilder(
+            example_input=None,
+            hf_id=hf_model_name,
+            auto_model=AutoModelForCausalLM,
+            hf_auth_token=hf_auth_token,
+            auto_tokenizer=AutoTokenizer,
+        )
+    else:
+        model_builder = HFTransformerBuilder(
+            example_input=None,
+            hf_id=hf_model_name,
+            auto_model=AutoModelForCausalLM,
+            hf_auth_token=hf_auth_token,
+            auto_tokenizer=AutoTokenizer,
+            model=model,
+            tokenizer=tokenizer,
+        )
+        
     if streaming_llm is True:
         enable_llama_pos_shift_attention(model_builder.model)
 

--- a/models/turbine_models/custom_models/llm_runner.py
+++ b/models/turbine_models/custom_models/llm_runner.py
@@ -208,7 +208,7 @@ def run_torch_llm(
     chat_sys_prompt=DEFAULT_CHAT_SYS_PROMPT,
     model=None,
     tokenizer=None,
-):  
+):
     if streaming_llm is True:
         enable_llama_pos_shift_attention(model)
 

--- a/models/turbine_models/custom_models/llm_runner.py
+++ b/models/turbine_models/custom_models/llm_runner.py
@@ -169,6 +169,7 @@ def run_llm(
     chat_mode=False,
     chat_sys_prompt=DEFAULT_CHAT_SYS_PROMPT,
 ):
+    print("STARTING RUN LLM")
     tokenizer = AutoTokenizer.from_pretrained(
         hf_model_name,
         use_fast=False,
@@ -180,6 +181,7 @@ def run_llm(
         external_weight_path=external_weight_path,
         streaming_llm=streaming_llm,
     )
+    print("INITIALIZATION COMPLETE")
     if not chat_mode:
         prompt = append_user_prompt(chat_sys_prompt, prompt)
         initial_input = tokenizer(prompt, return_tensors="pt")

--- a/models/turbine_models/custom_models/llm_runner.py
+++ b/models/turbine_models/custom_models/llm_runner.py
@@ -168,12 +168,14 @@ def run_llm(
     streaming_llm=False,
     chat_mode=False,
     chat_sys_prompt=DEFAULT_CHAT_SYS_PROMPT,
+    tokenizer=None,
 ):
-    tokenizer = AutoTokenizer.from_pretrained(
-        hf_model_name,
-        use_fast=False,
-        token=hf_auth_token,
-    )
+    if tokenizer == None:
+        tokenizer = AutoTokenizer.from_pretrained(
+            hf_model_name,
+            use_fast=False,
+            token=hf_auth_token,
+        )
     llm = SharkLLM(
         device=device,
         vmfb_path=vmfb_path,
@@ -206,40 +208,18 @@ def run_torch_llm(
     chat_sys_prompt=DEFAULT_CHAT_SYS_PROMPT,
     model=None,
     tokenizer=None,
-):
-    from turbine_models.model_builder import HFTransformerBuilder
-    from transformers import AutoModelForCausalLM
-
-    if model == None:
-        model_builder = HFTransformerBuilder(
-            example_input=None,
-            hf_id=hf_model_name,
-            auto_model=AutoModelForCausalLM,
-            hf_auth_token=hf_auth_token,
-            auto_tokenizer=AutoTokenizer,
-        )
-    else:
-        model_builder = HFTransformerBuilder(
-            example_input=None,
-            hf_id=hf_model_name,
-            auto_model=AutoModelForCausalLM,
-            hf_auth_token=hf_auth_token,
-            auto_tokenizer=AutoTokenizer,
-            model=model,
-            tokenizer=tokenizer,
-        )
-        
+):  
     if streaming_llm is True:
-        enable_llama_pos_shift_attention(model_builder.model)
+        enable_llama_pos_shift_attention(model)
 
     def get_token_from_logits(logits):
         return torch.argmax(logits[:, -1, :], dim=1)
 
     prompt = append_user_prompt(chat_sys_prompt, prompt)
-    initial_input = model_builder.tokenizer(prompt, return_tensors="pt")
+    initial_input = tokenizer(prompt, return_tensors="pt")
     example_input_id = initial_input.input_ids
 
-    model_results = model_builder.model.forward(example_input_id)
+    model_results = model.forward(example_input_id)
     model_token = get_token_from_logits(model_results.logits)
 
     pkv = model_results.past_key_values
@@ -247,14 +227,14 @@ def run_torch_llm(
     torch_results = []
     torch_results.append(int(model_token))
     while model_token != 2:
-        model_results = model_builder.model.forward(
+        model_results = model.forward(
             torch.unsqueeze(model_token, 0), past_key_values=pkv
         )
         model_token = get_token_from_logits(model_results.logits)
         pkv = model_results.past_key_values
         torch_results.append(int(model_token[0]))
 
-    return model_builder.tokenizer.decode(torch_results)
+    return tokenizer.decode(torch_results)
 
 
 if __name__ == "__main__":

--- a/models/turbine_models/custom_models/stateless_llama.py
+++ b/models/turbine_models/custom_models/stateless_llama.py
@@ -121,18 +121,21 @@ def export_transformer_model(
     streaming_llm=False,
     vmfb_path=None,
     upload_ir=False,
+    mod=None,
+    tokenizer=None,
 ):
-    tokenizer = AutoTokenizer.from_pretrained(
-        hf_model_name,
-        use_fast=False,
-        token=hf_auth_token,
-    )
-
-    mod = AutoModelForCausalLM.from_pretrained(
-        hf_model_name,
-        torch_dtype=torch.float,
-        token=hf_auth_token,
-    )
+    if tokenizer == None:
+        tokenizer = AutoTokenizer.from_pretrained(
+            hf_model_name,
+            use_fast=False,
+            token=hf_auth_token,
+        )
+    if mod == None:
+        mod = AutoModelForCausalLM.from_pretrained(
+            hf_model_name,
+            torch_dtype=torch.float,
+            token=hf_auth_token,
+        )
     schema_json = generate_schema(mod.config.num_hidden_layers)
     state_schema = pytree.treespec_loads(schema_json)
     if streaming_llm:

--- a/models/turbine_models/custom_models/stateless_llama.py
+++ b/models/turbine_models/custom_models/stateless_llama.py
@@ -475,6 +475,7 @@ def export_transformer_model(
         )
         if vmfb_path is None:
             vmfb_path = f"{safe_name}.vmfb"
+        print("RIGHT BEFORE SAVE TO VMFB")
         with open(vmfb_path, "wb+") as f:
             f.write(flatbuffer_blob)
         print("saved to ", safe_name + ".vmfb")

--- a/models/turbine_models/custom_models/stateless_llama.py
+++ b/models/turbine_models/custom_models/stateless_llama.py
@@ -475,7 +475,6 @@ def export_transformer_model(
         )
         if vmfb_path is None:
             vmfb_path = f"{safe_name}.vmfb"
-        print("RIGHT BEFORE SAVE TO VMFB")
         with open(vmfb_path, "wb+") as f:
             f.write(flatbuffer_blob)
         print("saved to ", safe_name + ".vmfb")

--- a/models/turbine_models/custom_models/stateless_llama.py
+++ b/models/turbine_models/custom_models/stateless_llama.py
@@ -165,7 +165,8 @@ def export_transformer_model(
             for name in mod_params:
                 mapper["params." + name] = name
             if external_weight_file:
-                safetensors.torch.save_file(mod_params, external_weight_file)
+                if os.path.exists(external_weight_file) == False:
+                    safetensors.torch.save_file(mod_params, external_weight_file)
 
         elif external_weights == "gguf":
             tensor_mapper = remap_gguf.TensorNameMap(remap_gguf.MODEL_ARCH.LLAMA, HEADS)

--- a/models/turbine_models/model_builder.py
+++ b/models/turbine_models/model_builder.py
@@ -30,6 +30,7 @@ class HFTransformerBuilder:
         model=None,
         model_type: str = None,
         compile_to_vmfb: bool = None,
+        tokenizer=None,
     ) -> None:
         self.example_input = example_input
         self.hf_id = hf_id
@@ -38,12 +39,13 @@ class HFTransformerBuilder:
         self.auto_config = auto_config
         self.hf_auth_token = hf_auth_token
         self.model = model
-        self.tokenizer = None
+        self.tokenizer = tokenizer
         self.upload_ir = upload_ir
         self.model_type = model_type
         self.compile_to_vmfb = compile_to_vmfb
         if self.model == None:
             self.build_model()
+
 
     def build_model(self) -> None:
         """

--- a/models/turbine_models/model_builder.py
+++ b/models/turbine_models/model_builder.py
@@ -46,7 +46,6 @@ class HFTransformerBuilder:
         if self.model == None:
             self.build_model()
 
-
     def build_model(self) -> None:
         """
         Builds a PyTorch model using Hugging Face's transformers library.

--- a/models/turbine_models/tests/stateless_llama_test.py
+++ b/models/turbine_models/tests/stateless_llama_test.py
@@ -9,7 +9,6 @@ import turbine_models.custom_models.stateless_llama as llama
 import os
 import unittest
 import difflib
-import tracemalloc
 from transformers import AutoTokenizer, AutoModelForCausalLM
 import torch
 
@@ -138,7 +137,6 @@ class StatelessLlamaChecks(unittest.TestCase):
         )
         # if cached, just read
         if os.path.exists(torch_str_cache_path):
-            print("CACHED TORCH STR")
             with open(torch_str_cache_path, "r") as f:
                 torch_str = f.read()
         else:
@@ -184,7 +182,6 @@ class StatelessLlamaChecks(unittest.TestCase):
         check_output_string(torch_str, rotated_torch_str)
 
     def test_kvcachce_schema(self):
-        print("HIIII")
         json_schema_16 = """[1, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}]}]"""
         num_layers = 8
         auto_schema_16 = llama.generate_schema(num_layers)
@@ -197,12 +194,5 @@ class StatelessLlamaChecks(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print("HIIII")
-    tracemalloc.start()
     logging.basicConfig(level=logging.DEBUG)
     unittest.main()
-    # displaying the memory
-    print("STORAGEE: " + str(tracemalloc.get_traced_memory()))
-    
-    # stopping the library
-    tracemalloc.stop()

--- a/models/turbine_models/tests/stateless_llama_test.py
+++ b/models/turbine_models/tests/stateless_llama_test.py
@@ -109,6 +109,7 @@ class StatelessLlamaChecks(unittest.TestCase):
             "Trelis/Llama-2-7b-chat-hf-function-calling-v2",
             None,
             f"Llama_2_7b_chat_hf_function_calling_v2_{precision}_{quantization}.safetensors",
+            tokenizer=tokenizer
         )
         check_output_string(torch_str, turbine_str)
 
@@ -160,6 +161,7 @@ class StatelessLlamaChecks(unittest.TestCase):
             None,
             f"Llama_2_7b_chat_hf_function_calling_v2_{precision}_{quantization}.safetensors",
             streaming_llm=True,
+            tokenizer=tokenizer
         )
         check_output_string(torch_str, turbine_str)
 

--- a/models/turbine_models/tests/stateless_llama_test.py
+++ b/models/turbine_models/tests/stateless_llama_test.py
@@ -41,6 +41,7 @@ tokenizer = AutoTokenizer.from_pretrained(
 mod = AutoModelForCausalLM.from_pretrained(
     "Trelis/Llama-2-7b-chat-hf-function-calling-v2",
     torch_dtype=torch.float,
+    device_map="auto",
 )
 
 
@@ -137,6 +138,7 @@ class StatelessLlamaChecks(unittest.TestCase):
         )
         # if cached, just read
         if os.path.exists(torch_str_cache_path):
+            print("CACHED TORCH STR")
             with open(torch_str_cache_path, "r") as f:
                 torch_str = f.read()
         else:
@@ -182,6 +184,7 @@ class StatelessLlamaChecks(unittest.TestCase):
         check_output_string(torch_str, rotated_torch_str)
 
     def test_kvcachce_schema(self):
+        print("HIIII")
         json_schema_16 = """[1, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}, {"type": "builtins.tuple", "context": "null", "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}]}]"""
         num_layers = 8
         auto_schema_16 = llama.generate_schema(num_layers)
@@ -194,6 +197,7 @@ class StatelessLlamaChecks(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    print("HIIII")
     tracemalloc.start()
     logging.basicConfig(level=logging.DEBUG)
     unittest.main()


### PR DESCRIPTION
This commit cleans up stateless llama testing and helps with memory efficiency by creating the model on the Meta device (with empty weights) and the state dict is then loaded inside it (shard by shard in the case of a sharded checkpoint). The sd test for `vae_encode` throws an error. I took a look at the mlir generated and the `encode_inp func` is there and inputs/return looks valid. Looks like it has to do with iree bump (`FuncConversion` pass). It also adds a CI job to run Jinchen's sdxl script nightly (one failure right now, hopefully fixed soon).