### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ please reach out to us on the `#turbine` channel of the
 
 ```
 pip install shark-turbine
-# Or editable: pip install -e core
+# Or for editable: see instructions under developers
 ```
 
 The above does install some unecessary cuda/cudnn packages for cpu use. To avoid this you


### PR DESCRIPTION
Using `pip install -e core` without installing requirements first skips the use of the -f command inside requirements files ( a security feature of pip), direct users to install requirements first separately. 