### PR TITLE
[rewriter] Add support for `hal` executables for merging modules

### DIFF
--- a/core/shark_turbine/transforms/merger.py
+++ b/core/shark_turbine/transforms/merger.py
@@ -132,6 +132,13 @@ class Merger:
             self._nested_symbol_table_ops.append(init_op)
             self._target_body.append(init_op)
 
+        # Merge external dispatches.
+        sources = get_top_level_ops(self.source_module, "hal.executable.source")
+        for source in sources:
+            source.detach_from_parent()
+            self._nested_symbol_table_ops.append(source)
+            self._target_body.append(source)
+
         # Merge functions.
         funcs = get_top_level_ops(self.source_module, "func.func")
         for func_op in funcs:

--- a/core/shark_turbine/transforms/rewriter.py
+++ b/core/shark_turbine/transforms/rewriter.py
@@ -320,7 +320,7 @@ def pass_main(pass_class: Type[Pass], *, argv=None):
     parser = argparse.ArgumentParser(description="Rewrite driver")
     parser.add_argument("input_file", help="File to process")
     parser.add_argument("-o", dest="output_file", help="Output file")
-    args = parser.parse_args(argv)
+    args, _ = parser.parse_known_args(argv)
 
     with Context() as context:
         with open(args.input_file, "r") as f:


### PR DESCRIPTION
To support rewriting custom dispatches into modules we need to support merging hal executables into modules. This occurs when rewriting in `flow.dispatch` operations.