### PR TITLE
update tank and add validation distinction for uploaded names

### DIFF
--- a/models/turbine_models/custom_models/sd_inference/clip.py
+++ b/models/turbine_models/custom_models/sd_inference/clip.py
@@ -145,7 +145,9 @@ def export_clip_model(
     if compile_to != "vmfb":
         return module_str, tokenizer
     else:
-        utils.compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name)
+        utils.compile_to_vmfb(
+            module_str, device, target_triple, max_alloc, safe_name, upload_ir
+        )
         if upload_ir:
             return blob_name
 

--- a/models/turbine_models/custom_models/sd_inference/clip.py
+++ b/models/turbine_models/custom_models/sd_inference/clip.py
@@ -138,7 +138,7 @@ def export_clip_model(
             f.write(module_str)
         model_name_upload = hf_model_name.replace("/", "_")
         model_name_upload += "-clip"
-        turbine_tank.uploadToBlobStorage(
+        blob_name = turbine_tank.uploadToBlobStorage(
             str(os.path.abspath(f"{safe_name}.mlir")),
             f"{model_name_upload}/{model_name_upload}.mlir",
         )
@@ -146,6 +146,8 @@ def export_clip_model(
         return module_str, tokenizer
     else:
         utils.compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name)
+        if upload_ir:
+            return blob_name
 
 
 if __name__ == "__main__":

--- a/models/turbine_models/custom_models/sd_inference/clip.py
+++ b/models/turbine_models/custom_models/sd_inference/clip.py
@@ -145,9 +145,7 @@ def export_clip_model(
     if compile_to != "vmfb":
         return module_str, tokenizer
     else:
-        utils.compile_to_vmfb(
-            module_str, device, target_triple, max_alloc, safe_name
-        )
+        utils.compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name)
         if upload_ir:
             return blob_name
 

--- a/models/turbine_models/custom_models/sd_inference/clip.py
+++ b/models/turbine_models/custom_models/sd_inference/clip.py
@@ -146,7 +146,7 @@ def export_clip_model(
         return module_str, tokenizer
     else:
         utils.compile_to_vmfb(
-            module_str, device, target_triple, max_alloc, safe_name, upload_ir
+            module_str, device, target_triple, max_alloc, safe_name
         )
         if upload_ir:
             return blob_name

--- a/models/turbine_models/custom_models/sd_inference/schedulers.py
+++ b/models/turbine_models/custom_models/sd_inference/schedulers.py
@@ -153,7 +153,7 @@ def export_scheduler(
             f.write(module_str)
         model_name_upload = hf_model_name.replace("/", "-")
         model_name_upload = model_name_upload + "_scheduler"
-        turbine_tank.uploadToBlobStorage(
+        blob_name = turbine_tank.uploadToBlobStorage(
             str(os.path.abspath(f"{safe_name}.mlir")),
             f"{model_name_upload}/{model_name_upload}.mlir",
         )
@@ -161,6 +161,8 @@ def export_scheduler(
         return module_str
     else:
         utils.compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name)
+        if upload_ir:
+            return blob_name
 
 
 if __name__ == "__main__":

--- a/models/turbine_models/custom_models/sd_inference/schedulers.py
+++ b/models/turbine_models/custom_models/sd_inference/schedulers.py
@@ -161,7 +161,7 @@ def export_scheduler(
         return module_str
     else:
         utils.compile_to_vmfb(
-            module_str, device, target_triple, max_alloc, safe_name, upload_ir
+            module_str, device, target_triple, max_alloc, safe_name
         )
         if upload_ir:
             return blob_name

--- a/models/turbine_models/custom_models/sd_inference/schedulers.py
+++ b/models/turbine_models/custom_models/sd_inference/schedulers.py
@@ -160,7 +160,9 @@ def export_scheduler(
     if compile_to != "vmfb":
         return module_str
     else:
-        utils.compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name)
+        utils.compile_to_vmfb(
+            module_str, device, target_triple, max_alloc, safe_name, upload_ir
+        )
         if upload_ir:
             return blob_name
 

--- a/models/turbine_models/custom_models/sd_inference/schedulers.py
+++ b/models/turbine_models/custom_models/sd_inference/schedulers.py
@@ -160,9 +160,7 @@ def export_scheduler(
     if compile_to != "vmfb":
         return module_str
     else:
-        utils.compile_to_vmfb(
-            module_str, device, target_triple, max_alloc, safe_name
-        )
+        utils.compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name)
         if upload_ir:
             return blob_name
 

--- a/models/turbine_models/custom_models/sd_inference/unet.py
+++ b/models/turbine_models/custom_models/sd_inference/unet.py
@@ -140,7 +140,7 @@ def export_unet_model(
         return module_str
     else:
         utils.compile_to_vmfb(
-            module_str, device, target_triple, max_alloc, safe_name, upload_ir
+            module_str, device, target_triple, max_alloc, safe_name
         )
         if upload_ir:
             return blob_name

--- a/models/turbine_models/custom_models/sd_inference/unet.py
+++ b/models/turbine_models/custom_models/sd_inference/unet.py
@@ -139,9 +139,7 @@ def export_unet_model(
     if compile_to != "vmfb":
         return module_str
     else:
-        utils.compile_to_vmfb(
-            module_str, device, target_triple, max_alloc, safe_name
-        )
+        utils.compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name)
         if upload_ir:
             return blob_name
 

--- a/models/turbine_models/custom_models/sd_inference/unet.py
+++ b/models/turbine_models/custom_models/sd_inference/unet.py
@@ -132,7 +132,7 @@ def export_unet_model(
             f.write(module_str)
         model_name_upload = hf_model_name.replace("/", "-")
         model_name_upload += "_unet"
-        turbine_tank.uploadToBlobStorage(
+        blob_name = turbine_tank.uploadToBlobStorage(
             str(os.path.abspath(f"{safe_name}.mlir")),
             f"{model_name_upload}/{model_name_upload}.mlir",
         )
@@ -140,6 +140,8 @@ def export_unet_model(
         return module_str
     else:
         utils.compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name)
+        if upload_ir:
+            return blob_name
 
 
 if __name__ == "__main__":

--- a/models/turbine_models/custom_models/sd_inference/unet.py
+++ b/models/turbine_models/custom_models/sd_inference/unet.py
@@ -139,7 +139,9 @@ def export_unet_model(
     if compile_to != "vmfb":
         return module_str
     else:
-        utils.compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name)
+        utils.compile_to_vmfb(
+            module_str, device, target_triple, max_alloc, safe_name, upload_ir
+        )
         if upload_ir:
             return blob_name
 

--- a/models/turbine_models/custom_models/sd_inference/utils.py
+++ b/models/turbine_models/custom_models/sd_inference/utils.py
@@ -30,7 +30,7 @@ def largest_error(array1, array2):
 
 
 def compile_to_vmfb(
-    module_str, device, target_triple, max_alloc, safe_name, upload_ir=False
+    module_str, device, target_triple, max_alloc, safe_name
 ):
     flags = [
         "--iree-input-type=torch",

--- a/models/turbine_models/custom_models/sd_inference/utils.py
+++ b/models/turbine_models/custom_models/sd_inference/utils.py
@@ -29,7 +29,9 @@ def largest_error(array1, array2):
     return max_error
 
 
-def compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name):
+def compile_to_vmfb(
+    module_str, device, target_triple, max_alloc, safe_name, upload_ir=False
+):
     flags = [
         "--iree-input-type=torch",
         "--mlir-print-debuginfo",
@@ -83,7 +85,10 @@ def compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name):
     with open(f"{safe_name}.vmfb", "wb+") as f:
         f.write(flatbuffer_blob)
     print("Saved to", safe_name + ".vmfb")
-    exit()
+    if upload_ir:
+        return
+    else:
+        exit()
 
 
 def create_safe_name(hf_model_name, model_name_str):

--- a/models/turbine_models/custom_models/sd_inference/utils.py
+++ b/models/turbine_models/custom_models/sd_inference/utils.py
@@ -29,9 +29,7 @@ def largest_error(array1, array2):
     return max_error
 
 
-def compile_to_vmfb(
-    module_str, device, target_triple, max_alloc, safe_name
-):
+def compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name):
     flags = [
         "--iree-input-type=torch",
         "--mlir-print-debuginfo",

--- a/models/turbine_models/custom_models/sd_inference/utils.py
+++ b/models/turbine_models/custom_models/sd_inference/utils.py
@@ -85,10 +85,6 @@ def compile_to_vmfb(
     with open(f"{safe_name}.vmfb", "wb+") as f:
         f.write(flatbuffer_blob)
     print("Saved to", safe_name + ".vmfb")
-    if upload_ir:
-        return
-    else:
-        exit()
 
 
 def create_safe_name(hf_model_name, model_name_str):

--- a/models/turbine_models/custom_models/sd_inference/vae.py
+++ b/models/turbine_models/custom_models/sd_inference/vae.py
@@ -127,7 +127,9 @@ def export_vae_model(
     if compile_to != "vmfb":
         return module_str
     else:
-        utils.compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name)
+        utils.compile_to_vmfb(
+            module_str, device, target_triple, max_alloc, safe_name, upload_ir
+        )
         if upload_ir:
             return blob_name
 

--- a/models/turbine_models/custom_models/sd_inference/vae.py
+++ b/models/turbine_models/custom_models/sd_inference/vae.py
@@ -127,9 +127,7 @@ def export_vae_model(
     if compile_to != "vmfb":
         return module_str
     else:
-        utils.compile_to_vmfb(
-            module_str, device, target_triple, max_alloc, safe_name
-        )
+        utils.compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name)
         if upload_ir:
             return blob_name
 

--- a/models/turbine_models/custom_models/sd_inference/vae.py
+++ b/models/turbine_models/custom_models/sd_inference/vae.py
@@ -128,7 +128,7 @@ def export_vae_model(
         return module_str
     else:
         utils.compile_to_vmfb(
-            module_str, device, target_triple, max_alloc, safe_name, upload_ir
+            module_str, device, target_triple, max_alloc, safe_name
         )
         if upload_ir:
             return blob_name

--- a/models/turbine_models/custom_models/sd_inference/vae.py
+++ b/models/turbine_models/custom_models/sd_inference/vae.py
@@ -120,7 +120,7 @@ def export_vae_model(
             f.write(module_str)
         model_name_upload = hf_model_name.replace("/", "_")
         model_name_upload = model_name_upload + "-vae-" + variant
-        turbine_tank.uploadToBlobStorage(
+        blob_name = turbine_tank.uploadToBlobStorage(
             str(os.path.abspath(f"{safe_name}.mlir")),
             f"{model_name_upload}/{model_name_upload}.mlir",
         )
@@ -128,6 +128,8 @@ def export_vae_model(
         return module_str
     else:
         utils.compile_to_vmfb(module_str, device, target_triple, max_alloc, safe_name)
+        if upload_ir:
+            return blob_name
 
 
 if __name__ == "__main__":

--- a/models/turbine_models/custom_models/stateless_llama.py
+++ b/models/turbine_models/custom_models/stateless_llama.py
@@ -416,7 +416,7 @@ def export_transformer_model(
         with open(f"{safe_name}.mlir", "w+") as f:
             f.write(module_str)
         model_name_upload = hf_model_name.replace("/", "_")
-        turbine_tank.uploadToBlobStorage(
+        blob_name = turbine_tank.uploadToBlobStorage(
             str(os.path.abspath(f"{safe_name}.mlir")),
             f"{model_name_upload}/{model_name_upload}.mlir",
         )
@@ -478,6 +478,8 @@ def export_transformer_model(
         with open(vmfb_path, "wb+") as f:
             f.write(flatbuffer_blob)
         print("saved to ", safe_name + ".vmfb")
+        if upload_ir:
+            return blob_name
         return module_str, tokenizer
 
 

--- a/models/turbine_models/tests/sd_test.py
+++ b/models/turbine_models/tests/sd_test.py
@@ -23,6 +23,7 @@ import unittest
 import os
 import copy
 import platform
+from turbine_models.turbine_tank import turbine_tank
 
 
 default_arguments = {
@@ -76,7 +77,7 @@ class StableDiffusionTest(unittest.TestCase):
         current_args["hf_model_name"] = "google/t5-v1_1-small"
         safe_prefix = "t5_v1_1_small"
         with self.assertRaises(SystemExit) as cm:
-            clip.export_clip_model(
+            blob_name = clip.export_clip_model(
                 hf_model_name=current_args["hf_model_name"],
                 hf_auth_token=None,
                 compile_to="vmfb",
@@ -106,6 +107,10 @@ class StableDiffusionTest(unittest.TestCase):
         assert err < 9e-4
         if platform.system() != "Windows":
             os.remove(current_args["vmfb_path"])
+        if UPLOAD_IR:
+            new_blob_name = blob_name.split(".")
+            new_blob_name = new_blob_name[0] + "-pass.mlir"
+            turbine_tank.changeBlobName(blob_name, new_blob_name)
         del current_args
 
     def testExportClipVitLarge14(self):
@@ -113,7 +118,7 @@ class StableDiffusionTest(unittest.TestCase):
         current_args["hf_model_name"] = "openai/clip-vit-large-patch14"
         safe_prefix = "clip_vit_large_patch14"
         with self.assertRaises(SystemExit) as cm:
-            clip.export_clip_model(
+            blob_name = clip.export_clip_model(
                 hf_model_name=current_args["hf_model_name"],
                 hf_auth_token=None,
                 compile_to="vmfb",
@@ -142,6 +147,10 @@ class StableDiffusionTest(unittest.TestCase):
         )
         err = utils.largest_error(torch_output, turbine[0])
         assert err < 9e-5
+        if UPLOAD_IR:
+            new_blob_name = blob_name.split(".")
+            new_blob_name = new_blob_name[0] + "-pass.mlir"
+            turbine_tank.changeBlobName(blob_name, new_blob_name)
         if platform.system() != "Windows":
             os.remove(current_args["external_weight_path"])
             os.remove(current_args["vmfb_path"])
@@ -150,7 +159,7 @@ class StableDiffusionTest(unittest.TestCase):
         current_args = copy.deepcopy(default_arguments)
         current_args["hf_model_name"] = "CompVis/stable-diffusion-v1-4"
         with self.assertRaises(SystemExit) as cm:
-            clip.export_clip_model(
+            blob_name = clip.export_clip_model(
                 # This is a public model, so no auth required
                 "CompVis/stable-diffusion-v1-4",
                 None,
@@ -178,13 +187,17 @@ class StableDiffusionTest(unittest.TestCase):
         )
         err = utils.largest_error(torch_output, turbine[0])
         assert err < 9e-5
+        if UPLOAD_IR:
+            new_blob_name = blob_name.split(".")
+            new_blob_name = new_blob_name[0] + "-pass.mlir"
+            turbine_tank.changeBlobName(blob_name, new_blob_name)
         os.remove("stable_diffusion_v1_4_clip.safetensors")
         os.remove("stable_diffusion_v1_4_clip.vmfb")
 
     def testExportUnetModel(self):
         current_args = copy.deepcopy(default_arguments)
         with self.assertRaises(SystemExit) as cm:
-            unet.export_unet_model(
+            blob_name = unet.export_unet_model(
                 unet_model,
                 # This is a public model, so no auth required
                 "CompVis/stable-diffusion-v1-4",
@@ -230,13 +243,17 @@ class StableDiffusionTest(unittest.TestCase):
         )
         err = utils.largest_error(torch_output, turbine)
         assert err < 9e-5
+        if UPLOAD_IR:
+            new_blob_name = blob_name.split(".")
+            new_blob_name = new_blob_name[0] + "-pass.mlir"
+            turbine_tank.changeBlobName(blob_name, new_blob_name)
         os.remove("stable_diffusion_v1_4_unet.safetensors")
         os.remove("stable_diffusion_v1_4_unet.vmfb")
 
     def testExportVaeModelDecode(self):
         current_args = copy.deepcopy(default_arguments)
         with self.assertRaises(SystemExit) as cm:
-            vae.export_vae_model(
+            blob_name = vae.export_vae_model(
                 vae_model,
                 # This is a public model, so no auth required
                 "CompVis/stable-diffusion-v1-4",
@@ -277,6 +294,10 @@ class StableDiffusionTest(unittest.TestCase):
         )
         err = utils.largest_error(torch_output, turbine)
         assert err < 9e-5
+        if UPLOAD_IR:
+            new_blob_name = blob_name.split(".")
+            new_blob_name = new_blob_name[0] + "-pass.mlir"
+            turbine_tank.changeBlobName(blob_name, new_blob_name)
         os.remove("stable_diffusion_v1_4_vae.safetensors")
         os.remove("stable_diffusion_v1_4_vae.vmfb")
 
@@ -285,7 +306,7 @@ class StableDiffusionTest(unittest.TestCase):
     def testExportVaeModelEncode(self):
         current_args = copy.deepcopy(default_arguments)
         with self.assertRaises(SystemExit) as cm:
-            vae.export_vae_model(
+            blob_name = vae.export_vae_model(
                 vae_model,
                 # This is a public model, so no auth required
                 "CompVis/stable-diffusion-v1-4",
@@ -326,6 +347,10 @@ class StableDiffusionTest(unittest.TestCase):
         )
         err = utils.largest_error(torch_output, turbine)
         assert err < 3e-3
+        if UPLOAD_IR:
+            new_blob_name = blob_name.split(".")
+            new_blob_name = new_blob_name[0] + "-pass.mlir"
+            turbine_tank.changeBlobName(blob_name, new_blob_name)
         os.remove("stable_diffusion_v1_4_vae.safetensors")
         os.remove("stable_diffusion_v1_4_vae.vmfb")
 
@@ -334,7 +359,7 @@ class StableDiffusionTest(unittest.TestCase):
         current_args = copy.deepcopy(default_arguments)
         safe_name = "stable_diffusion_v1_4_scheduler"
         with self.assertRaises(SystemExit) as cm:
-            schedulers.export_scheduler(
+            blob_name = schedulers.export_scheduler(
                 scheduler_module,
                 # This is a public model, so no auth required
                 "CompVis/stable-diffusion-v1-4",
@@ -377,6 +402,10 @@ class StableDiffusionTest(unittest.TestCase):
         )
         err = utils.largest_error(torch_output, turbine)
         assert err < 9e-3
+        if UPLOAD_IR:
+            new_blob_name = blob_name.split(".")
+            new_blob_name = new_blob_name[0] + "-pass.mlir"
+            turbine_tank.changeBlobName(blob_name, new_blob_name)
         os.remove("stable_diffusion_v1_4_scheduler.safetensors")
         os.remove("stable_diffusion_v1_4_scheduler.vmfb")
 

--- a/models/turbine_models/tests/sd_test.py
+++ b/models/turbine_models/tests/sd_test.py
@@ -88,6 +88,8 @@ class StableDiffusionTest(unittest.TestCase):
                 max_alloc=None,
                 upload_ir=UPLOAD_IR,
             )
+            if UPLOAD_IR:
+                exit()
         self.assertEqual(cm.exception.code, None)
         current_args["vmfb_path"] = safe_prefix + "_clip.vmfb"
         turbine = clip_runner.run_clip(
@@ -129,6 +131,8 @@ class StableDiffusionTest(unittest.TestCase):
                 max_alloc=None,
                 upload_ir=UPLOAD_IR,
             )
+            if UPLOAD_IR:
+                exit()
         self.assertEqual(cm.exception.code, None)
         current_args["external_weight_path"] = safe_prefix + ".safetensors"
         current_args["vmfb_path"] = safe_prefix + "_clip.vmfb"
@@ -169,6 +173,8 @@ class StableDiffusionTest(unittest.TestCase):
                 "cpu",
                 upload_ir=UPLOAD_IR,
             )
+            if UPLOAD_IR:
+                exit()
         self.assertEqual(cm.exception.code, None)
         current_args["external_weight_path"] = "stable_diffusion_v1_4_clip.safetensors"
         current_args["vmfb_path"] = "stable_diffusion_v1_4_clip.vmfb"
@@ -211,6 +217,8 @@ class StableDiffusionTest(unittest.TestCase):
                 "cpu",
                 upload_ir=UPLOAD_IR,
             )
+            if UPLOAD_IR:
+                exit()
         self.assertEqual(cm.exception.code, None)
         current_args["external_weight_path"] = "stable_diffusion_v1_4_unet.safetensors"
         current_args["vmfb_path"] = "stable_diffusion_v1_4_unet.vmfb"
@@ -268,6 +276,8 @@ class StableDiffusionTest(unittest.TestCase):
                 variant="decode",
                 upload_ir=UPLOAD_IR,
             )
+            if UPLOAD_IR:
+                exit()
         self.assertEqual(cm.exception.code, None)
         current_args["external_weight_path"] = "stable_diffusion_v1_4_vae.safetensors"
         current_args["vmfb_path"] = "stable_diffusion_v1_4_vae.vmfb"
@@ -321,6 +331,8 @@ class StableDiffusionTest(unittest.TestCase):
                 variant="encode",
                 upload_ir=UPLOAD_IR,
             )
+            if UPLOAD_IR:
+                exit()
         self.assertEqual(cm.exception.code, None)
         current_args["external_weight_path"] = "stable_diffusion_v1_4_vae.safetensors"
         current_args["vmfb_path"] = "stable_diffusion_v1_4_vae.vmfb"
@@ -373,6 +385,8 @@ class StableDiffusionTest(unittest.TestCase):
                 "cpu",
                 upload_ir=UPLOAD_IR,
             )
+            if UPLOAD_IR:
+                exit()
         self.assertEqual(cm.exception.code, None)
         current_args["external_weight_path"] = safe_name + ".safetensors"
         current_args["vmfb_path"] = safe_name + ".vmfb"

--- a/models/turbine_models/tests/sd_test.py
+++ b/models/turbine_models/tests/sd_test.py
@@ -76,21 +76,17 @@ class StableDiffusionTest(unittest.TestCase):
         current_args = copy.deepcopy(default_arguments)
         current_args["hf_model_name"] = "google/t5-v1_1-small"
         safe_prefix = "t5_v1_1_small"
-        with self.assertRaises(SystemExit) as cm:
-            blob_name = clip.export_clip_model(
-                hf_model_name=current_args["hf_model_name"],
-                hf_auth_token=None,
-                compile_to="vmfb",
-                external_weights=None,
-                external_weight_path=None,
-                device="cpu",
-                target_triple=None,
-                max_alloc=None,
-                upload_ir=UPLOAD_IR,
-            )
-            if UPLOAD_IR:
-                exit()
-        self.assertEqual(cm.exception.code, None)
+        blob_name = clip.export_clip_model(
+            hf_model_name=current_args["hf_model_name"],
+            hf_auth_token=None,
+            compile_to="vmfb",
+            external_weights=None,
+            external_weight_path=None,
+            device="cpu",
+            target_triple=None,
+            max_alloc=None,
+            upload_ir=UPLOAD_IR,
+        )
         current_args["vmfb_path"] = safe_prefix + "_clip.vmfb"
         turbine = clip_runner.run_clip(
             current_args["device"],
@@ -119,21 +115,17 @@ class StableDiffusionTest(unittest.TestCase):
         current_args = copy.deepcopy(default_arguments)
         current_args["hf_model_name"] = "openai/clip-vit-large-patch14"
         safe_prefix = "clip_vit_large_patch14"
-        with self.assertRaises(SystemExit) as cm:
-            blob_name = clip.export_clip_model(
-                hf_model_name=current_args["hf_model_name"],
-                hf_auth_token=None,
-                compile_to="vmfb",
-                external_weights="safetensors",
-                external_weight_path=safe_prefix + ".safetensors",
-                device="cpu",
-                target_triple=None,
-                max_alloc=None,
-                upload_ir=UPLOAD_IR,
-            )
-            if UPLOAD_IR:
-                exit()
-        self.assertEqual(cm.exception.code, None)
+        blob_name = clip.export_clip_model(
+            hf_model_name=current_args["hf_model_name"],
+            hf_auth_token=None,
+            compile_to="vmfb",
+            external_weights="safetensors",
+            external_weight_path=safe_prefix + ".safetensors",
+            device="cpu",
+            target_triple=None,
+            max_alloc=None,
+            upload_ir=UPLOAD_IR,
+        )
         current_args["external_weight_path"] = safe_prefix + ".safetensors"
         current_args["vmfb_path"] = safe_prefix + "_clip.vmfb"
         turbine = clip_runner.run_clip(
@@ -162,20 +154,16 @@ class StableDiffusionTest(unittest.TestCase):
     def testExportClipModel(self):
         current_args = copy.deepcopy(default_arguments)
         current_args["hf_model_name"] = "CompVis/stable-diffusion-v1-4"
-        with self.assertRaises(SystemExit) as cm:
-            blob_name = clip.export_clip_model(
-                # This is a public model, so no auth required
-                "CompVis/stable-diffusion-v1-4",
-                None,
-                "vmfb",
-                "safetensors",
-                "stable_diffusion_v1_4_clip.safetensors",
-                "cpu",
-                upload_ir=UPLOAD_IR,
-            )
-            if UPLOAD_IR:
-                exit()
-        self.assertEqual(cm.exception.code, None)
+        blob_name = clip.export_clip_model(
+            # This is a public model, so no auth required
+            "CompVis/stable-diffusion-v1-4",
+            None,
+            "vmfb",
+            "safetensors",
+            "stable_diffusion_v1_4_clip.safetensors",
+            "cpu",
+            upload_ir=UPLOAD_IR,
+        )
         current_args["external_weight_path"] = "stable_diffusion_v1_4_clip.safetensors"
         current_args["vmfb_path"] = "stable_diffusion_v1_4_clip.vmfb"
         turbine = clip_runner.run_clip(
@@ -202,24 +190,20 @@ class StableDiffusionTest(unittest.TestCase):
 
     def testExportUnetModel(self):
         current_args = copy.deepcopy(default_arguments)
-        with self.assertRaises(SystemExit) as cm:
-            blob_name = unet.export_unet_model(
-                unet_model,
-                # This is a public model, so no auth required
-                "CompVis/stable-diffusion-v1-4",
-                current_args["batch_size"],
-                current_args["height"],
-                current_args["width"],
-                None,
-                "vmfb",
-                "safetensors",
-                "stable_diffusion_v1_4_unet.safetensors",
-                "cpu",
-                upload_ir=UPLOAD_IR,
-            )
-            if UPLOAD_IR:
-                exit()
-        self.assertEqual(cm.exception.code, None)
+        blob_name = unet.export_unet_model(
+            unet_model,
+            # This is a public model, so no auth required
+            "CompVis/stable-diffusion-v1-4",
+            current_args["batch_size"],
+            current_args["height"],
+            current_args["width"],
+            None,
+            "vmfb",
+            "safetensors",
+            "stable_diffusion_v1_4_unet.safetensors",
+            "cpu",
+            upload_ir=UPLOAD_IR,
+        )
         current_args["external_weight_path"] = "stable_diffusion_v1_4_unet.safetensors"
         current_args["vmfb_path"] = "stable_diffusion_v1_4_unet.vmfb"
         sample = torch.rand(
@@ -260,25 +244,21 @@ class StableDiffusionTest(unittest.TestCase):
 
     def testExportVaeModelDecode(self):
         current_args = copy.deepcopy(default_arguments)
-        with self.assertRaises(SystemExit) as cm:
-            blob_name = vae.export_vae_model(
-                vae_model,
-                # This is a public model, so no auth required
-                "CompVis/stable-diffusion-v1-4",
-                current_args["batch_size"],
-                current_args["height"],
-                current_args["width"],
-                None,
-                "vmfb",
-                "safetensors",
-                "stable_diffusion_v1_4_vae.safetensors",
-                "cpu",
-                variant="decode",
-                upload_ir=UPLOAD_IR,
-            )
-            if UPLOAD_IR:
-                exit()
-        self.assertEqual(cm.exception.code, None)
+        blob_name = vae.export_vae_model(
+            vae_model,
+            # This is a public model, so no auth required
+            "CompVis/stable-diffusion-v1-4",
+            current_args["batch_size"],
+            current_args["height"],
+            current_args["width"],
+            None,
+            "vmfb",
+            "safetensors",
+            "stable_diffusion_v1_4_vae.safetensors",
+            "cpu",
+            variant="decode",
+            upload_ir=UPLOAD_IR,
+        )
         current_args["external_weight_path"] = "stable_diffusion_v1_4_vae.safetensors"
         current_args["vmfb_path"] = "stable_diffusion_v1_4_vae.vmfb"
         example_input = torch.rand(
@@ -315,25 +295,21 @@ class StableDiffusionTest(unittest.TestCase):
     @unittest.expectedFailure
     def testExportVaeModelEncode(self):
         current_args = copy.deepcopy(default_arguments)
-        with self.assertRaises(SystemExit) as cm:
-            blob_name = vae.export_vae_model(
-                vae_model,
-                # This is a public model, so no auth required
-                "CompVis/stable-diffusion-v1-4",
-                current_args["batch_size"],
-                current_args["height"],
-                current_args["width"],
-                None,
-                "vmfb",
-                "safetensors",
-                "stable_diffusion_v1_4_vae.safetensors",
-                "cpu",
-                variant="encode",
-                upload_ir=UPLOAD_IR,
-            )
-            if UPLOAD_IR:
-                exit()
-        self.assertEqual(cm.exception.code, None)
+        blob_name = vae.export_vae_model(
+            vae_model,
+            # This is a public model, so no auth required
+            "CompVis/stable-diffusion-v1-4",
+            current_args["batch_size"],
+            current_args["height"],
+            current_args["width"],
+            None,
+            "vmfb",
+            "safetensors",
+            "stable_diffusion_v1_4_vae.safetensors",
+            "cpu",
+            variant="encode",
+            upload_ir=UPLOAD_IR,
+        )
         current_args["external_weight_path"] = "stable_diffusion_v1_4_vae.safetensors"
         current_args["vmfb_path"] = "stable_diffusion_v1_4_vae.vmfb"
         example_input = torch.rand(
@@ -370,24 +346,20 @@ class StableDiffusionTest(unittest.TestCase):
     def testExportPNDMScheduler(self):
         current_args = copy.deepcopy(default_arguments)
         safe_name = "stable_diffusion_v1_4_scheduler"
-        with self.assertRaises(SystemExit) as cm:
-            blob_name = schedulers.export_scheduler(
-                scheduler_module,
-                # This is a public model, so no auth required
-                "CompVis/stable-diffusion-v1-4",
-                current_args["batch_size"],
-                current_args["height"],
-                current_args["width"],
-                None,
-                "vmfb",
-                "safetensors",
-                "stable_diffusion_v1_4_scheduler.safetensors",
-                "cpu",
-                upload_ir=UPLOAD_IR,
-            )
-            if UPLOAD_IR:
-                exit()
-        self.assertEqual(cm.exception.code, None)
+        blob_name = schedulers.export_scheduler(
+            scheduler_module,
+            # This is a public model, so no auth required
+            "CompVis/stable-diffusion-v1-4",
+            current_args["batch_size"],
+            current_args["height"],
+            current_args["width"],
+            None,
+            "vmfb",
+            "safetensors",
+            "stable_diffusion_v1_4_scheduler.safetensors",
+            "cpu",
+            upload_ir=UPLOAD_IR,
+        )
         current_args["external_weight_path"] = safe_name + ".safetensors"
         current_args["vmfb_path"] = safe_name + ".vmfb"
         sample = torch.rand(

--- a/models/turbine_models/tests/stateless_llama_test.py
+++ b/models/turbine_models/tests/stateless_llama_test.py
@@ -22,6 +22,7 @@ from turbine_models.custom_models import llm_runner
 from turbine_models.gen_external_params.gen_external_params import (
     gen_external_params,
 )
+from turbine_models.turbine_tank import turbine_tank
 
 
 def check_output_string(reference, output):
@@ -86,7 +87,7 @@ class StatelessLlamaChecks(unittest.TestCase):
 
         upload_ir_var = os.environ.get("TURBINE_TANK_ACTION", "not_upload")
 
-        llama.export_transformer_model(
+        blob_name = llama.export_transformer_model(
             hf_model_name="Trelis/Llama-2-7b-chat-hf-function-calling-v2",
             hf_auth_token=None,
             compile_to="vmfb",
@@ -130,6 +131,10 @@ class StatelessLlamaChecks(unittest.TestCase):
             tokenizer=self.tokenizer,
         )
         check_output_string(torch_str, turbine_str)
+        if upload_ir_var == "upload":
+            new_blob_name = blob_name.split(".")
+            new_blob_name = new_blob_name[0] + "-pass.mlir"
+            turbine_tank.changeBlobName(blob_name, new_blob_name)
 
     def test_streaming_vmfb_comparison(self):
         """


### PR DESCRIPTION
This commit makes minor changes to the model testing and base models, so that there is a difference between validated and failing mlir names in the turbinetank.