### PR TITLE
Support auto externalization of tensors/params/buffers and normalize export API.

### DIFF
--- a/core/iree-requirements.txt
+++ b/core/iree-requirements.txt
@@ -1,2 +1,2 @@
-iree-compiler==20240403.851
-iree-runtime==20240403.851
+iree-compiler==20240410.859
+iree-runtime==20240410.859

--- a/core/shark_turbine/aot/__init__.py
+++ b/core/shark_turbine/aot/__init__.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .builtins import *
-from .compiled_module import CompiledModule
+from .compiled_module import *
 from .decompositions import *
 from .exporter import *
 from .fx_programs import FxPrograms, FxProgramsBuilder

--- a/core/shark_turbine/aot/__init__.py
+++ b/core/shark_turbine/aot/__init__.py
@@ -9,3 +9,5 @@ from .compiled_module import *
 from .decompositions import *
 from .exporter import *
 from .fx_programs import FxPrograms, FxProgramsBuilder
+from .tensor_traits import *
+from .params import *

--- a/core/shark_turbine/aot/compiled_module.py
+++ b/core/shark_turbine/aot/compiled_module.py
@@ -46,7 +46,6 @@ from .support.ir_utils import (
 
 __all__ = [
     "CompiledModule",
-    "CompiledModuleMeta",
 ]
 
 ################################################################################
@@ -347,6 +346,7 @@ def _uncallable_public_export(*args, **kwargs):
 
 
 _COMPILED_MODULE_API_ATTRIBUTES = [
+    "create_from_dict",
     "expand_custom_ops",
     "export_global",
     "get_class_info",
@@ -428,6 +428,25 @@ class CompiledModuleMeta(type):
 
 class CompiledModule(metaclass=CompiledModuleMeta):
     """Base class for all staged modules."""
+
+    @classmethod
+    def create_from_dict(
+        cls: CompiledModuleMeta,
+        name: str,
+        dct: dict,
+        *,
+        export_name: Optional[str] = None,
+    ) -> CompiledModuleMeta:
+        """Creates a CompiledModule subclass with an explicit dictionary of members.
+
+        This is the unsugared form of:
+
+        ```
+        class Foo(CompiledModule, export_name="bar"):
+          def member(): ...
+        ```
+        """
+        return CompiledModuleMeta(name, (cls,), dct, export_name=export_name)
 
     @staticmethod
     def get_class_info(cls: CompiledModuleMeta) -> CompiledModuleClassInfo:

--- a/core/shark_turbine/aot/compiled_module.py
+++ b/core/shark_turbine/aot/compiled_module.py
@@ -46,6 +46,7 @@ from .support.ir_utils import (
 
 __all__ = [
     "CompiledModule",
+    "CompiledModuleMeta",
 ]
 
 ################################################################################

--- a/core/shark_turbine/aot/exporter.py
+++ b/core/shark_turbine/aot/exporter.py
@@ -4,10 +4,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import overload, Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 import io
 from pathlib import Path
 import platform
+import warnings
 
 import torch
 
@@ -25,9 +26,9 @@ from ..support.ir_imports import (
 from .builtins import *
 from .compiled_module import (
     CompiledModule,
-    CompiledModuleMeta,
     ImportPhase,
 )
+from .fx_programs import FxPrograms
 from . import decompositions
 
 __all__ = [
@@ -38,7 +39,12 @@ __all__ = [
 _is_windows = platform.system() == "Windows"
 
 
-ModuleLike = Union[torch.nn.Module, CompiledModuleMeta, torch.export.ExportedProgram]
+ModuleLike = Union[
+    torch.nn.Module,
+    Type[CompiledModule],
+    torch.export.ExportedProgram,
+    FxPrograms,
+]
 SaveableTarget = Union[str, Path, None, Output]
 
 
@@ -150,16 +156,67 @@ class ExportOutput:
             return None
 
 
+@overload
+def export(
+    module: torch.nn.Module,
+    /,
+    *,
+    args: Optional[tuple] = None,
+    kwargs: Optional[Dict[str, Any]] = None,
+    dynamic_shapes: Dict[str, Any] | Tuple[Any] | List[Any] | None = None,
+    module_name: Optional[str] = None,
+    function_name: Optional[str] = None,
+) -> ExportOutput:
+    """Exports a torch.nn.Module.
+
+    This is done by first invoking torch.export.export with args, kwargs,
+    and dynamic_shapes.
+    """
+    ...
+
+
+@overload
+def export(compiled_module: Type[CompiledModule], /) -> ExportOutput:
+    """Exports a CompiledModule and returns the output."""
+    ...
+
+
+@overload
+def export(
+    exported_program: torch.export.ExportedProgram,
+    /,
+    *,
+    module_name: Optional[str] = None,
+    function_name: Optional[str] = None,
+) -> ExportOutput:
+    """Exports a single entry-point module consisting of an ExportedProgram."""
+    ...
+
+
+@overload
+def export(
+    exported_programs: FxPrograms,
+    /,
+    *,
+    module_name: Optional[str] = None,
+) -> ExportOutput:
+    """Exports a multi entry-point ExportedProgram."""
+    ...
+
+
 def export(
     mdl: ModuleLike,
+    /,
     *example_args: torch.Tensor,
     args: Optional[tuple] = None,
     kwargs: Optional[Dict[str, Any]] = None,
     dynamic_shapes: Dict[str, Any] | Tuple[Any] | List[Any] | None = None,
-    external_params: bool = False,
-    global_params: bool = True,
+    module_name: Optional[str] = None,
+    function_name: Optional[str] = None,
 ) -> ExportOutput:
-    """One shot export of an nn.Module or CompiledModule.
+    """Generic export of supported entities.
+
+    See a more specific overload for accepted forms.
 
     This function behaves differently based on the type of the `mdl` argument:
 
@@ -177,37 +234,31 @@ def export(
         must be empty.
       kwargs: Example keyword arguments.
       dynamic_shapes: Dynamic shape specs to pass to torch.export.
-      external_params: Whether to declare parameters as external vs inlining
-        contents.
-      global_params: Whether to promote module parameters to globals eagerly
-        (vs relying on explicit). Default True.
 
     Returns:
       An ExportOutput object that wraps the compilation and provides
       easy access.
     """
+    if len(example_args) > 0:
+        warnings.warn(
+            DeprecationWarning(
+                "extra `example_args` positional parameters are deprecated: pass `args=tuple(...)` instead."
+            )
+        )
+
     TransformedModule: Any
     current_decomps = decompositions.current_aot_decompositions()
     if isinstance(mdl, torch.export.ExportedProgram):
-        if (
-            len(example_args) > 0
-            or args is not None
-            or kwargs is not None
-            or dynamic_shapes is not None
-        ):
-            raise ValueError(
-                "If passing an ExportedProgram to aot.export, cannot also pass "
-                "args, example_args, kwargs, or dynamic_dims"
-            )
+        TransformedModule = CompiledModule.create_from_dict(
+            "LambdaCompiledModule",
+            {(function_name or "main"): mdl},
+            export_name=module_name or "module",
+        )
 
-        class EpExported(CompiledModule, export_name=mdl.graph_module._get_name()):
-            if global_params:
-                params = export_global_tree(
-                    dict(list(mdl.named_parameters())), external=external_params
-                )
-            main = mdl
-
-        TransformedModule = EpExported
+    elif isinstance(mdl, FxPrograms):
+        TransformedModule = CompiledModule.create_from_dict(
+            "LambdaCompiledModule", mdl.programs, export_name=module_name or "module"
+        )
     elif isinstance(mdl, torch.nn.Module):
         # Normalize arguments for torch.export.
         if args is None:
@@ -226,24 +277,13 @@ def export(
             _patch_op_dispatch_for_export()
             exported_program = exported_program.run_decompositions(current_decomps)
 
-        class Exported(CompiledModule, export_name=nn_module._get_name()):
-            if global_params:
-                params = export_parameters(nn_module, external=external_params)
-            main = exported_program
-
-        TransformedModule = Exported
+        TransformedModule = CompiledModule.create_from_dict(
+            "LambdaCompiledModule",
+            {(function_name or "main"): exported_program},
+            export_name=module_name or "module",
+        )
     else:
-        assert isinstance(mdl, CompiledModuleMeta)
-        if (
-            len(example_args) > 0
-            or args is not None
-            or kwargs is not None
-            or dynamic_shapes is not None
-        ):
-            raise ValueError(
-                "If passing a CompiledModule to aot.export, cannot also pass "
-                "args, example_args, kwargs, or dynamic_dims"
-            )
+        assert issubclass(type(mdl), CompiledModule)
         TransformedModule = mdl
 
     session = Session()

--- a/core/shark_turbine/aot/params.py
+++ b/core/shark_turbine/aot/params.py
@@ -1,0 +1,180 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Iterator, Optional, Set, Tuple, Union
+
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+from iree.runtime import (
+    ParameterIndex,
+)
+
+################################################################################
+# External tensor type
+################################################################################
+
+
+class ExternalTensor(torch.Tensor):
+    """Tensor which is backed by a real tensor and carries metadata tieing
+    it to an external parameter pack.
+
+    See: https://github.com/albanD/subclass_zoo/blob/main/trivial_tensors.py
+    """
+
+    _is_turbine_external_tensor: bool
+    external_scope: str
+    external_name: str
+
+    @staticmethod
+    def __new__(
+        cls, data, *, requires_grad=None, external_name: str, external_scope: str = ""
+    ):
+        if requires_grad is None:
+            return torch.Tensor.__new__(cls, data)
+        else:
+            return cls._make_subclass(cls, data, requires_grad)
+
+    def __init__(
+        self, data, *, external_name: str, external_scope: str = "", requires_grad=None
+    ):
+        super().__init__()
+        self.data = data
+        if isinstance(data, nn.Parameter):
+            # Magic that makes the instanceof check report as a Parameter.
+            self._is_param = True
+        self._is_turbine_external_tensor = True
+        self.external_scope = external_scope
+        self.external_name = external_name
+
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+
+def externalize_module_parameters(
+    module: nn.Module, *, external_scope: str = "", prefix: str = ""
+):
+    """Externalizes parameters and persistent buffers in a module by name."""
+
+    def externalize(state_dict: dict, prefix: str, item_name: str, item: torch.Tensor):
+        full_name = f"{prefix}.{item_name}" if prefix else item_name
+        external_item = ExternalTensor(
+            item,
+            requires_grad=item.requires_grad,
+            external_scope=external_scope,
+            external_name=full_name,
+        )
+        torch.utils.swap_tensors(item, external_item)
+
+    memo: Set[str] = set()
+    for sub_name, sub_module in module.named_modules(prefix=prefix):
+        state_dict = sub_module.state_dict()
+        for param_name, param in sub_module.named_parameters(recurse=False):
+            if param_name in memo:
+                continue
+            if param_name not in state_dict:
+                # Non persistent
+                continue
+            memo.add(param_name)
+            externalize(state_dict, sub_name, param_name, param)
+        for buffer_name, buffer in sub_module.named_buffers(recurse=False):
+            if buffer_name in memo:
+                continue
+            memo.add(buffer_name)
+            if buffer_name not in state_dict:
+                # Non persistent
+                continue
+            externalize(state_dict, sub_name, buffer_name, buffer)
+
+
+################################################################################
+# Parameter archives save/load
+################################################################################
+
+
+def save_module_parameters(
+    file_path: Union[str, Path], module: nn.Module, *, prefix: str = ""
+):
+    """One shot save of parameters and persistent buffers on a module.
+
+    More options are available by using a ParameterArchiveBuilder.
+    """
+    builder = ParameterArchiveBuilder()
+    builder.add_module(module, prefix=prefix)
+    builder.save(file_path)
+
+
+class ParameterArchive:
+    """Allows access to a parameter archive as CPU tensors."""
+
+    def __init__(self, file_path: Optional[Union[str, Path]] = None):
+        self._index = ParameterIndex()
+        if file_path is not None:
+            self.load(file_path)
+
+        # for i in range(len(self._index)):
+        #     entry = self._index[i]
+        #     file_handle, offset = entry.file_storage
+        #     view = file_handle.view[offset:offset + entry.length]
+
+    def load(
+        self,
+        file_path: Union[str, Path],
+        *,
+        readable: bool = True,
+        writable: bool = False
+    ):
+        """Loads index entries from a file adding them to the in-memory archive."""
+        self._index.load(file_path, readable=readable, writable=writable)
+
+    def __repr__(self):
+        return repr(self._index)
+
+
+class ParameterArchiveBuilder:
+    """Helper for building parameter archives from live modules."""
+
+    def __init__(self):
+        self._index = ParameterIndex()
+
+    def save(self, file_path: Union[str, Path]):
+        """Saves the archive."""
+        self._index.create_archive_file(str(file_path))
+
+    def add_tensor(self, name: str, tensor: torch.Tensor):
+        """Adds an named tensor to the archive."""
+        host_array = tensor.detach().cpu().contiguous().numpy()
+        self._index.add_buffer(name, host_array)
+
+    def add_module(self, module: nn.Module, *, prefix: str = ""):
+        """Adds all parameters and persistent buffers from a module hierarchy."""
+        for name, t in self._yield_saveable_tensors(module, prefix=prefix):
+            self.add_tensor(name, t)
+
+    def _yield_saveable_tensors(
+        self, module: nn.Module, *, prefix: str = ""
+    ) -> Iterator[Tuple[str, torch.Tensor]]:
+        memo: Set[str] = set()
+        for sub_name, sub_module in module.named_modules(prefix=prefix):
+            state_dict = sub_module.state_dict()
+            for param_name, param in sub_module.named_parameters(
+                prefix=sub_name, recurse=False
+            ):
+                if param_name in memo:
+                    continue
+                memo.add(param_name)
+                yield param_name, param
+            for buffer_name, buffer in sub_module.named_buffers(
+                prefix=sub_name, recurse=False
+            ):
+                if buffer_name in memo:
+                    continue
+                memo.add(buffer_name)
+                if buffer_name not in state_dict:
+                    # Non persistent
+                    continue
+                yield buffer_name, buffer

--- a/core/shark_turbine/aot/params.py
+++ b/core/shark_turbine/aot/params.py
@@ -126,7 +126,7 @@ class ParameterArchive:
         file_path: Union[str, Path],
         *,
         readable: bool = True,
-        writable: bool = False
+        writable: bool = False,
     ):
         """Loads index entries from a file adding them to the in-memory archive."""
         self._index.load(file_path, readable=readable, writable=writable)

--- a/core/shark_turbine/aot/support/procedural/exported_program.py
+++ b/core/shark_turbine/aot/support/procedural/exported_program.py
@@ -70,6 +70,10 @@ from .tracer import (
     IrTrace,
 )
 
+# Limit of tensor volumes. Over this limit, otherwise uncategorized tensor
+# constants will be emitted out-of-line. Under the limit, inline.
+INLINE_TENSOR_VOLUME_LIMIT = 1024
+
 
 class ExportedProgramIntrinsic(CallableIntrinsic):
     def __init__(
@@ -281,7 +285,7 @@ class _Hooks(FxImporterHooks):
         if external_trait is not None:
             return True
         volume = math.prod(literal.shape)
-        return volume > 1024
+        return volume > INLINE_TENSOR_VOLUME_LIMIT
 
 
 class AutoGlobalTensorDef(GlobalsDef):

--- a/core/shark_turbine/aot/tensor_traits.py
+++ b/core/shark_turbine/aot/tensor_traits.py
@@ -1,0 +1,36 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Optional
+from dataclasses import dataclass
+
+import torch
+
+
+__all__ = [
+    "ExternalTensorTrait",
+]
+
+
+@dataclass
+class ExternalTensorTrait:
+    """Represents a 'trait' that can be applied to a Tensor to signal that
+    it is to be loaded by name from an external archive at AOT execution time.
+    """
+
+    external_scope: str
+    external_name: str
+
+    @staticmethod
+    def get(from_tensor: torch.Tensor) -> Optional["ExternalTensorTrait"]:
+        existing = getattr(from_tensor, "_turbine_external_tensor_trait", None)
+        if existing is None:
+            return None
+        assert isinstance(existing, ExternalTensorTrait)
+        return existing
+
+    def set(self, to_tensor: torch.Tensor):
+        to_tensor._turbine_external_tensor_trait = self  # type: ignore

--- a/core/tests/aot/compiled_exported_program_test.py
+++ b/core/tests/aot/compiled_exported_program_test.py
@@ -107,12 +107,8 @@ class TorchExportTests(unittest.TestCase):
         inst = ParamsAsGlobalsModule(context=Context(), import_to="import")
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
-        self.assertIn(
-            "util.global private @_params.classifier.weight {noinline}", module_str
-        )
-        self.assertIn(
-            "util.global private @_params.classifier.bias {noinline}", module_str
-        )
+        self.assertIn("util.global private @_params.classifier.weight", module_str)
+        self.assertIn("util.global private @_params.classifier.bias", module_str)
         # Should only be two.
         self.assertEqual(2, module_str.count("util.global private"))
         # And two loads each loads.

--- a/core/tests/aot/globals_test.py
+++ b/core/tests/aot/globals_test.py
@@ -179,12 +179,12 @@ class GlobalsTest(unittest.TestCase):
         inst = ScalarState(context=Context())
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
-        self.assertIn("@_state_index.global {noinline} = 0 : index", module_str)
-        self.assertIn("@_state_f32.global {noinline} = 0.000000e+00 : f32", module_str)
-        self.assertIn("@_state_f64.global {noinline} = 0.000000e+00 : f64", module_str)
-        self.assertIn("@_state_i32.global {noinline} = 0 : i32", module_str)
-        self.assertIn("@_state_i64.global {noinline} = 0 : i64", module_str)
-        self.assertIn("@_state_bool.global {noinline} = false", module_str)
+        self.assertIn("@_state_index.global = 0 : index", module_str)
+        self.assertIn("@_state_f32.global = 0.000000e+00 : f32", module_str)
+        self.assertIn("@_state_f64.global = 0.000000e+00 : f64", module_str)
+        self.assertIn("@_state_i32.global = 0 : i32", module_str)
+        self.assertIn("@_state_i64.global = 0 : i64", module_str)
+        self.assertIn("@_state_bool.global = false", module_str)
 
     def testInheritExportScalars(self):
         class BaseState(CompiledModule):
@@ -200,8 +200,8 @@ class GlobalsTest(unittest.TestCase):
         inst = DerivedState(context=Context())
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
-        self.assertIn("@_state_index.global {noinline} = 0 : index", module_str)
-        self.assertIn("@_state_f32.global {noinline} = 0.000000e+00 : f32", module_str)
+        self.assertIn("@_state_index.global = 0 : index", module_str)
+        self.assertIn("@_state_f32.global = 0.000000e+00 : f32", module_str)
 
     def testInheritOverrideBase(self):
         class BaseState(CompiledModule):
@@ -218,10 +218,8 @@ class GlobalsTest(unittest.TestCase):
         inst = DerivedState(context=Context(), import_to="full")
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
-        self.assertIn("@_state_index.global {noinline} = 0 : index", module_str)
-        self.assertNotIn(
-            "@_state_f32.global {noinline} = 0.000000e+00 : f32", module_str
-        )
+        self.assertIn("@_state_index.global = 0 : index", module_str)
+        self.assertNotIn("@_state_f32.global = 0.000000e+00 : f32", module_str)
         self.assertIn("return %_state_index.global : index", module_str)
 
     def testInheritExportModules(self):
@@ -266,15 +264,15 @@ class GlobalsTest(unittest.TestCase):
         module_str = str(CompiledModule.get_mlir_module(inst))
         print(module_str)
         self.assertIn(
-            "util.global private mutable @_state0.seq.0 {noinline} = dense<0> : tensor<1xi32>",
+            "util.global private mutable @_state0.seq.0 = dense<0> : tensor<1xi32>",
             module_str,
         )
         self.assertIn(
-            "util.global private mutable @_state0.seq.1 {noinline} = dense<0.000000e+00> : tensor<2xf64>",
+            "util.global private mutable @_state0.seq.1 = dense<0.000000e+00> : tensor<2xf64>",
             module_str,
         )
         self.assertIn(
-            "util.global private mutable @_state0.seq.2 {noinline} = dense<0> : tensor<3xi64>",
+            "util.global private mutable @_state0.seq.2 = dense<0> : tensor<3xi64>",
             module_str,
         )
         self.assertIn("util.global private mutable @_state0.data", module_str)

--- a/core/tests/aot/params_test.py
+++ b/core/tests/aot/params_test.py
@@ -1,0 +1,80 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+import unittest
+
+import torch
+import torch.nn as nn
+
+from iree.runtime import (
+    ParameterIndex,
+    ParameterProvider,
+)
+
+from shark_turbine.aot import (
+    export,
+)
+
+from shark_turbine.aot.params import (
+    externalize_module_parameters,
+    save_module_parameters,
+    ExternalTensor,
+    ParameterArchive,
+)
+
+
+class SimpleParamsModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.classifier = nn.Linear(20, 30)
+
+    def forward(self, x):
+        return self.classifier(x)
+
+
+class ParamsTest(unittest.TestCase):
+    def testCreateArchive(self):
+        file_path = "/tmp/mystuff.irpa"
+        m = SimpleParamsModule()
+        save_module_parameters(file_path, m)
+        archive = ParameterArchive(file_path)
+        print(archive)
+
+    def testExportExternalized(self):
+        m = SimpleParamsModule()
+        externalize_module_parameters(m)
+        export(m, args=(torch.empty([128, 20]),), global_params=False).print_readable()
+
+
+class ExternalTensorTest(unittest.TestCase):
+
+    def testBackedExternalTensor(self):
+        inner_t = torch.ones([2, 3], dtype=torch.float32)
+        t = ExternalTensor(
+            inner_t, requires_grad=True, external_name="foobar", external_scope="main"
+        )
+        self.assertIs(type(t), ExternalTensor)
+        self.assertTrue(t._is_turbine_external_tensor)
+        self.assertEqual("main", t.external_scope)
+        self.assertEqual("foobar", t.external_name)
+        r = t + 1
+        self.assertFalse(hasattr(r, "_is_turbine_external_tensor"))
+        self.assertFalse(hasattr(r, "external_name"))
+        self.assertFalse(hasattr(r, "external_scope"))
+
+    def testParameter(self):
+        p = nn.Parameter(torch.ones([2, 3], dtype=torch.float32))
+        t = ExternalTensor(p, external_name="foobar", external_scope="main")
+        self.assertIs(type(t), ExternalTensor)
+        self.assertTrue(t._is_turbine_external_tensor)
+        self.assertEqual("main", t.external_scope)
+        self.assertEqual("foobar", t.external_name)
+        self.assertTrue(isinstance(t, nn.Parameter))
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/core/tests/aot/params_test.py
+++ b/core/tests/aot/params_test.py
@@ -51,7 +51,6 @@ class ParamsTest(unittest.TestCase):
 
 
 class ExternalTensorTest(unittest.TestCase):
-
     def testBackedExternalTensor(self):
         inner_t = torch.ones([2, 3], dtype=torch.float32)
         t = ExternalTensor(
@@ -74,6 +73,7 @@ class ExternalTensorTest(unittest.TestCase):
         self.assertEqual("main", t.external_scope)
         self.assertEqual("foobar", t.external_name)
         self.assertTrue(isinstance(t, nn.Parameter))
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)

--- a/llm/turbine_llm/examples/export_paged_llm_v1.py
+++ b/llm/turbine_llm/examples/export_paged_llm_v1.py
@@ -8,9 +8,7 @@
 
 import torch
 
-from shark_turbine.aot import (
-    FxProgramsBuilder,
-)
+from shark_turbine.aot import *
 
 from ..layers import *
 
@@ -55,6 +53,8 @@ def main():
             "cache_state": [{0: page_dim}],
         }
 
+        print(f"Exporting prefill_bs{bs}")
+
         @fxb.export_program(
             name=f"prefill_bs{bs}",
             args=(tokens, seq_lens, seq_block_ids, cache_state),
@@ -87,6 +87,8 @@ def main():
             "seq_block_ids": {1: block_dim},
             "cache_state": [{0: page_dim}],
         }
+
+        print(f"Exporting decode_bs{bs}")
 
         @fxb.export_program(
             name=f"decode_bs{bs}",
@@ -123,12 +125,22 @@ def main():
             )
             return logits
 
-    generate_batch_prefill(16)
-    generate_batch_decode(16)
+    generate_batch_prefill(4)
+    generate_batch_decode(4)
+    # generate_batch_prefill(2)
     print("GENERATED!")
 
     for name, ep in fxb.programs.items():
         print(f"EXPORT {name}:\n{ep}")
+
+    print("Creating CompiledModule")
+    BatchedLlamaV1 = CompiledModuleMeta(
+        "BatchedLlamaV1", (CompiledModule,), fxb.programs
+    )
+    print("Exporting")
+    output = export(BatchedLlamaV1)
+    print("Saving")
+    output.save_mlir("/tmp/batch_llama_v1.mlir")
 
 
 if __name__ == "__main__":

--- a/llm/turbine_llm/examples/export_paged_llm_v1.py
+++ b/llm/turbine_llm/examples/export_paged_llm_v1.py
@@ -127,18 +127,13 @@ def main():
 
     generate_batch_prefill(4)
     generate_batch_decode(4)
-    # generate_batch_prefill(2)
     print("GENERATED!")
 
     for name, ep in fxb.programs.items():
         print(f"EXPORT {name}:\n{ep}")
 
-    print("Creating CompiledModule")
-    BatchedLlamaV1 = CompiledModuleMeta(
-        "BatchedLlamaV1", (CompiledModule,), fxb.programs
-    )
     print("Exporting")
-    output = export(BatchedLlamaV1)
+    output = export(fxb)
     print("Saving")
     output.save_mlir("/tmp/batch_llama_v1.mlir")
 

--- a/llm/turbine_llm/layers/data.py
+++ b/llm/turbine_llm/layers/data.py
@@ -59,7 +59,7 @@ class PrimitiveTensor(InferenceTensor):
     """
 
     @abstractmethod
-    def as_torch(self) -> torch.Tensor:
+    def as_torch(self, *, dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         """Accesses the raw data as a torch tensor.
 
         If the tensor is packed in some way, this may bare no resemblance to
@@ -75,7 +75,9 @@ class DefaultPrimitiveTensor(PrimitiveTensor):
         super().__init__(name, list(data.shape))
         self._data = data
 
-    def as_torch(self) -> torch.Tensor:
+    def as_torch(self, *, dtype: Optional[torch.dtype] = None) -> torch.Tensor:
+        if dtype is not None:
+            return self._data.to(dtype)
         return self._data
 
     @property
@@ -280,7 +282,7 @@ class InferenceOps:
             )
         elif isinstance(rhs, PrimitiveTensor):
             # Convertible to a Torch tensor without custom layout.
-            rhs_torch = rhs.as_torch()
+            rhs_torch = rhs.as_torch(dtype=lhs.dtype)
             return _matmul_torch(
                 lhs,
                 rhs_torch,


### PR DESCRIPTION
This changes the behavior of `aot.export()` by:

* Auto exporting literal tensors that are not otherwise configured. This uses a heuristic to decide whether to inline them or emit them as uniqued, out of line globals.
* Removes the options to `externalize_params=` on `export`. This is now done explicitly by the user prior to calling `export` (see below). This feature was never fully usable like this so it is not believed to have any live uses (people who were using external params features were constructing their own `CompiledModule` exactly as they wanted).
* Adds explicit typing overloads for the four use cases:
  * Export a `torch.nn.Module` (via `torch.export`)
  * Export a pre-constructed `CompiledModule` as a single entry-point
  * Export a pre-exported `torch.export.ExportedProgram` as a single entry-point
  * Export an `FxPrograms` representing a multiple entry-point `torch.export.ExportedProgram` set

Adds APIs:

* `aot.ExternalTensorTrait`: dataclass that contains information about how to externalize the tensor at compile time.
* `CompiledModule.create_from_dict`: Programmatic construction of a `CompiledModule` without using the `class` sugared form.
* `aot.externalize_module_parameters(module)`: Sets `ExportedTensorTrait` on all tensors in the module tree that are parameters or persistent buffers. Such tensors will be emitted to load from an external parameters file when exported.
* `aot.save_module_parameters`: One-stop construction of a parameter archive (IRPA file) from the current values of all parameters and persistent buffers in the module tree.
* `class ParameterArchive`: Wrapper around an IREE `ParameterIndex` with access helpers for interop with torch tensors.
* `class ParameterArchiveBuilder`: Wrapper around an IREE `ParameterIndex` supporting easy construction of IRPA files from torch tensors and modules.

Other behavior changes:

* `{noinline}` removed from global definitions by default (it did default to this).
* turbine_llm misc changes to support auto export of dataset tensors so that they are associated with the originating data file (i.e. gguf file).

Example of exporting a module such that its parameters will be saved to an IRPA file and loaded externally at runtime from it.

```
m = SimpleParamsModule()
externalize_module_parameters(m)
save_module_parameters("/tmp/params.irpa", m)
export(m, args=(torch.empty([128, 20]),)).print_readable()
```

Includes bump of IREE to 20240410.859 (picks up parameters changes to runtime).