### PR TITLE
[llm] Generalize the KV cache to support both direct and paged caches.

### DIFF
--- a/llm/turbine_llm/examples/export_paged_llm_v1.py
+++ b/llm/turbine_llm/examples/export_paged_llm_v1.py
@@ -120,8 +120,7 @@ def main():
                 attention_mask=attention_mask,
                 start_positions=start_positions,
                 seq_block_ids=seq_block_ids,
-                read_cache_state=cache_state,
-                write_cache_state=cache_state,
+                cache_state=cache_state,
             )
             return logits
 

--- a/llm/turbine_llm/examples/paged_llm_v1.py
+++ b/llm/turbine_llm/examples/paged_llm_v1.py
@@ -14,7 +14,7 @@ import torch
 from ..layers import *
 
 # TODO: Should be using a base class with the protocol supported.
-from ..models.llama.llama import PagedLlamaModelV1
+from ..models.llama.llama import *
 from ..utils.debugging import trace_tensor
 from ..utils.tokenizer import InferenceTokenizer, load_tokenizer
 
@@ -32,7 +32,12 @@ class TorchGenerator:
     ):
         self.model = model
         self.tokenizer = tokenizer
-        self.cache_state = model.cache.allocate(page_cache_size, dtype=torch.float32)
+        if model.cache.is_paged:
+            self.shared_cache_state = model.cache.allocate(
+                page_cache_size, dtype=torch.float32
+            )
+        else:
+            self.shared_cache_state = None
         self.free_pages = list(range(1, 128))
         self.end_token = end_token
 
@@ -42,28 +47,45 @@ class TorchGenerator:
 
     def begin_batch(self, prompts: list[str]):
         token_ids, seq_lens = self.tokenizer.encode(
-            prompts, pad_to_multiple_of=self.model.cache.block_seq_stride
+            prompts, pad_to_multiple_of=self.model.cache.pad_sequence_stride
         )
         token_ids = torch.tensor(token_ids)
         seq_lens = torch.tensor(seq_lens)
-        return Batch(self, token_ids, seq_lens)
+        if self.shared_cache_state is not None:
+            cache_state = self.shared_cache_state
+        else:
+            cache_state = self.model.cache.direct.allocate(
+                bs=len(prompts), dtype=torch.float32
+            )
+        return Batch(self, token_ids, seq_lens, cache_state)
 
     def alloc_page(self) -> int:
+        if self.model.cache.is_direct:
+            # We don't allocate block ids for the direct cache.
+            return 0
+
         return self.free_pages.pop()
 
     def release_page(self, index: int):
+        if self.model.cache.is_direct:
+            return
         self.free_pages.append(index)
 
 
 class Batch:
     def __init__(
-        self, parent: TorchGenerator, token_ids: torch.Tensor, seq_lens: torch.Tensor
+        self,
+        parent: TorchGenerator,
+        token_ids: torch.Tensor,
+        seq_lens: torch.Tensor,
+        cache_state: list[torch.Tensor],
     ):
         self.bs = token_ids.shape[0]
         assert seq_lens.shape[0] == self.bs
         self.parent = parent
         self.token_ids = token_ids
         self.seq_lens = seq_lens
+        self.cache_state = cache_state
         self.results: list[list[int]] = [[] for _ in range(self.bs)]
         self.done_result_indices: set[int] = set()
 
@@ -71,7 +93,9 @@ class Batch:
         seq_stride = self.parent.block_seq_stride
         self.seq_block_ids: list[list[int]] = []
         for seq_len in self.seq_lens:
-            blocks_needed = int(math.ceil(seq_len / seq_stride))
+            blocks_needed = (
+                int(math.ceil(seq_len / seq_stride)) if seq_stride > 0 else 0
+            )
             row = []
             for _ in range(blocks_needed):
                 row.append(self.parent.alloc_page())
@@ -126,7 +150,7 @@ class Batch:
             self.token_ids,
             attention_mask=attention_mask,
             seq_block_ids=seq_block_ids_tensor,
-            cache_state=self.parent.cache_state,
+            cache_state=self.cache_state,
         )
         # TODO: Normalize the output of extract_tokens_from_logits into
         # tensor [bs, 1].
@@ -160,8 +184,8 @@ class Batch:
             attention_mask=decode_attention_mask,
             start_positions=start_positions,
             seq_block_ids=seq_block_ids_tensor,
-            read_cache_state=self.parent.cache_state,
-            write_cache_state=self.parent.cache_state,
+            read_cache_state=self.cache_state,
+            write_cache_state=self.cache_state,
         )
         trace_tensor("decode.logits", logits)
         # TODO: Normalize the output of extract_tokens_from_logits into
@@ -192,8 +216,14 @@ def main():
     dataset = gguf.load_file(data_files["gguf"])
     prompts = args.prompt
 
-    hp = configs.LlamaHParams.from_gguf_props(dataset.properties)
-    model = PagedLlamaModelV1(dataset.root_theta, hp)
+    direct_kv_cache = False
+
+    config = LlamaModelConfig(
+        hp=configs.LlamaHParams.from_gguf_props(dataset.properties),
+        block_seq_stride=16,
+        kv_cache_type="direct" if direct_kv_cache else "paged",
+    )
+    model = PagedLlamaModelV1(dataset.root_theta, config)
     generator = TorchGenerator(model, tokenizer)
 
     print(f":: Prompting:")

--- a/llm/turbine_llm/examples/validate_paged_llama_model.py
+++ b/llm/turbine_llm/examples/validate_paged_llama_model.py
@@ -17,7 +17,7 @@ def main(args: list[str]):
     config = gguf.load_file(args[0])
     hp = configs.LlamaHParams.from_gguf_props(config.properties)
     model = PagedLlamaModelV1(config.root_theta, hp)
-    cache_state = model.cache.allocate(128, torch.float32)
+    cache_state = model.cache.paged.allocate(128, torch.float32)
     start_index = 0
     next_batch = torch.tensor(
         [
@@ -118,8 +118,7 @@ def main(args: list[str]):
         attention_mask=decode_attention_mask,
         start_positions=start_positions,
         seq_block_ids=seq_block_ids,
-        read_cache_state=cache_state,
-        write_cache_state=cache_state,
+        cache_state=cache_state,
     )
     tokens = torch.tensor(
         model.extract_tokens_from_logits(logits, [1, 1, 1, 1])

--- a/llm/turbine_llm/layers/__init__.py
+++ b/llm/turbine_llm/layers/__init__.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .base import BaseLayer, ThetaLayer
-from .kv_cache import PagedKVCache
+from .kv_cache import BaseKVCache, DirectKVCache, PagedKVCache
 from .causal_llm import BaseCausalLMModel
 from .data import (
     Dataset,

--- a/llm/turbine_llm/layers/configs/llm_configs.py
+++ b/llm/turbine_llm/layers/configs/llm_configs.py
@@ -37,6 +37,7 @@ class LlamaHParams:
     feed_forward_length: int
     rope_dimension_count: int
     attention_head_count: int
+    attn_head_dim: int
     attention_layer_norm_rms_epsilon: float
     attention_head_count_kv: int
 
@@ -50,6 +51,7 @@ class LlamaHParams:
             embedding_length=_int_prop(p, "llama.embedding_length"),
             block_count=_int_prop(p, "llama.block_count"),
             feed_forward_length=_int_prop(p, "llama.feed_forward_length"),
+            attn_head_dim=_int_prop(p, "llama.rope.dimension_count"),
             rope_dimension_count=_int_prop(p, "llama.rope.dimension_count"),
             attention_head_count=attention_head_count,
             attention_layer_norm_rms_epsilon=_float_prop(

--- a/llm/turbine_llm/models/llama/llama.py
+++ b/llm/turbine_llm/models/llama/llama.py
@@ -6,6 +6,7 @@
 
 from typing import Optional
 
+from dataclasses import dataclass
 import math
 
 import torch
@@ -16,8 +17,46 @@ from ...layers import *
 
 
 __all__ = [
+    "LlamaModelConfig",
     "PagedLlamaModelV1",
 ]
+
+################################################################################
+# Config
+################################################################################
+
+
+@dataclass
+class LlamaModelConfig:
+    hp: configs.LlamaHParams
+
+    # Block sequence stride for a paged KV cache. This must divide evenly
+    # into the context length.
+    block_seq_stride: int = 16
+
+    # Either "paged" or "direct".
+    kv_cache_type: str = "paged"
+
+    def create_kv_cache(self) -> BaseKVCache:
+        hp = self.hp
+        if self.kv_cache_type == "direct":
+            return DirectKVCache(
+                block_seq_stride=self.block_seq_stride,
+                transformer_block_count=hp.block_count,
+                attn_head_count=hp.attention_head_count_kv,
+                attn_head_dim=hp.attn_head_dim,
+                seq_length=hp.context_length,
+            )
+        elif self.kv_cache_type == "paged":
+            return PagedKVCache(
+                transformer_block_count=hp.block_count,
+                attn_head_count=hp.attention_head_count_kv,
+                attn_head_dim=hp.attn_head_dim,
+                cache_partition_count=2,  # One for each of K/V.
+                block_seq_stride=self.block_seq_stride,
+            )
+        else:
+            raise NotImplementedError(f"kv_cache_type = {self.kv_cache_type}")
 
 
 ################################################################################
@@ -47,19 +86,12 @@ class PagedLlamaModelV1(BaseCausalLMModel):
     Various samplers and schedulers can be interleaved throughout.
     """
 
-    def __init__(self, theta: Theta, hp: configs.LlamaHParams):
-        super().__init__(theta, context_length=hp.context_length)
+    def __init__(self, theta: Theta, config: LlamaModelConfig):
+        hp = config.hp
+        super().__init__(theta, context_length=config.hp.context_length)
+        self.config = config
         self.hp = hp
-        # TODO: It doesn't seem like this is the right way to be getting the
-        # innermost attention dim.
-        attn_head_dim = self.attn_head_dim = hp.rope_dimension_count
-        self.cache = PagedKVCache(
-            transformer_block_count=hp.block_count,
-            attn_head_count=hp.attention_head_count_kv,
-            attn_head_dim=attn_head_dim,
-            cache_partition_count=2,
-            block_seq_stride=16,
-        )
+        self.cache = config.create_kv_cache()
         self.add_module(
             "token_embedding",
             TokenEmbeddingLayer(theta("token_embd"), dtype=hp.activation_dtype),
@@ -86,7 +118,7 @@ class PagedLlamaModelV1(BaseCausalLMModel):
                     block_index=n,
                     cache=self.cache,
                     head_count=hp.attention_head_count,
-                    head_dim=attn_head_dim,
+                    head_dim=hp.attn_head_dim,
                     head_count_kv=hp.attention_head_count_kv,
                     rms_epsilon=hp.attention_layer_norm_rms_epsilon,
                 )
@@ -155,7 +187,7 @@ class PagedLlamaModelV1(BaseCausalLMModel):
                 bs,
                 self.context_length,
                 self.hp.attention_head_count_kv,
-                self.attn_head_dim,
+                self.hp.attn_head_dim,
             ],
             dtype=self.hp.activation_dtype,
         )
@@ -164,7 +196,7 @@ class PagedLlamaModelV1(BaseCausalLMModel):
                 bs,
                 self.context_length,
                 self.hp.attention_head_count_kv,
-                self.attn_head_dim,
+                self.hp.attn_head_dim,
             ],
             dtype=self.hp.activation_dtype,
         )
@@ -280,68 +312,29 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         # count of kv heads to the count of attention heads used by the q.
         assert self.head_count == self.head_count_kv, "NYI: KV expansion"
 
-        xk_cache_update = xk
-        xv_cache_update = xv
-
-        # Manage the cache.
-        if read_cache_state is None:
-            # If not instructed to read from the cache, we assume this is
-            # prefill and the projected K/V values represent the complete
-            # sequence.
-            # Commit the whole cache if writing is enabled.
-            if write_cache_state is not None:
-                # TODO: Do a full pages write or a single row write, depending
-                # on whether prefill vs decode.
-                if read_cache_state is None:
-                    # Overwrite the whole cache.
-                    self.cache.write(
-                        write_cache_state,
-                        cache_partitions=[xk_cache_update, xv_cache_update],
-                        transformer_block_index=self.block_index,
-                        page_ids=seq_block_ids,
-                    )
-        else:
-            # We need to initialize/read the K/V from the cache for the whole
-            # sequence. Note that at this point, it is possible to fork and
-            # use a memory efficient attention kernel that can do indirect
-            # reads, skipping this materialization. This path is taken for
-            # a decode step.
-            assert start_positions is not None
-            assert xk_temp is not None and xv_temp is not None
-
-            kv_seq_len = seq_block_ids.shape[1] * self.cache.block_seq_stride
-
-            if write_cache_state:
-                # Write our one updated cache row into the cache.
-                self.cache.write_timestep(
-                    write_cache_state,
-                    cache_partitions=[
-                        xk_cache_update,
-                        xv_cache_update,
-                    ],
-                    transformer_block_index=self.block_index,
-                    seq_positions=start_positions + 1,
-                    page_ids=seq_block_ids,
-                )
-
-            # Restore from the cache.
-            self.cache.read(
-                read_cache_state,
-                read_into_partitions=[
-                    xk_temp[:, 0:kv_seq_len, ...],
-                    xv_temp[:, 0:kv_seq_len, ...],
-                ],
-                transformer_block_index=self.block_index,
-                page_ids=seq_block_ids,
+        if self.cache.is_paged:
+            xk, xv = self.transact_cache_paged(
+                xk_cache_update=xk,
+                xv_cache_update=xv,
+                seq_block_ids=seq_block_ids,
+                start_positions=start_positions,
+                write_cache_state=write_cache_state,
+                read_cache_state=read_cache_state,
+                xk_temp=xk_temp,
+                xv_temp=xv_temp,
             )
-
-            # For computation, we create a subview of the xk/xv tensors to have
-            # a sequence length covering the blocked size. This must include
-            # the newly added row (the caller is responsible for ensuring that
-            # every block has at least one row left). We'll compute on this
-            # ragged view and use an appropriate mask.
-            xk = xk_temp[:, 0:kv_seq_len, ...]
-            xv = xv_temp[:, 0:kv_seq_len, ...]
+        elif self.cache.is_direct:
+            xk, xv = self.transact_cache_direct(
+                xk_cache_update=xk,
+                xv_cache_update=xv,
+                start_positions=start_positions,
+                # TODO: Nasty way to get at this.
+                kv_seq_len=attention_mask.shape[3],
+                # TODO: Kill the read/write cache state distinction.
+                cache_state=write_cache_state or read_cache_state,
+            )
+        else:
+            raise NotImplementedError(f"Unsupported KV cache type: {type(self.cache)}")
 
         # Tranpose into [bs, heads, sl, dim]
         xq = xq.transpose(1, 2)
@@ -376,3 +369,112 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         final_output = h + ffn_down
 
         return final_output
+
+    def transact_cache_direct(
+        self,
+        *,
+        xk_cache_update: torch.Tensor,
+        xv_cache_update: torch.Tensor,
+        start_positions: Optional[torch.Tensor] = None,
+        kv_seq_len: int,
+        cache_state: list[torch.Tensor] = None,
+    ):
+        bs, batch_seq_len, _, _ = xk_cache_update.shape
+        cache_k = cache_state[self.block_index * 2]
+        cache_v = cache_state[self.block_index * 2 + 1]
+
+        if start_positions is None:
+            # Prefill. Write the entire cache.
+            cache_k[:, :batch_seq_len] = xk_cache_update
+            cache_v[:, :batch_seq_len] = xv_cache_update
+            return xk_cache_update, xv_cache_update
+        else:
+            # Decode. Write a single timestep.
+            # TODO: This needs to be reworked with index ops.
+            max_start_pos = 0
+            for row_index in range(bs):
+                row_start_pos = start_positions[row_index].item()
+                max_start_pos = max(row_start_pos, max_start_pos)
+                cache_k[row_index, row_start_pos : row_start_pos + 1] = xk_cache_update[
+                    row_index
+                ]
+                cache_v[row_index, row_start_pos : row_start_pos + 1] = xv_cache_update[
+                    row_index
+                ]
+            return cache_k[:, :kv_seq_len], cache_v[:, :kv_seq_len]
+
+    def transact_cache_paged(
+        self,
+        *,
+        xk_cache_update: torch.Tensor,
+        xv_cache_update: torch.Tensor,
+        # [bs, batch_seq_len // block_seq_stride]
+        seq_block_ids: torch.Tensor,
+        start_positions: Optional[torch.Tensor] = None,
+        write_cache_state: Optional[list[torch.Tensor]] = None,
+        read_cache_state: Optional[list[torch.Tensor]] = None,
+        xk_temp: Optional[torch.Tensor] = None,
+        xv_temp: Optional[torch.Tensor] = None,
+    ):
+        cache = self.cache.paged
+        # Manage the cache.
+        if read_cache_state is None:
+            # If not instructed to read from the cache, we assume this is
+            # prefill and the projected K/V values represent the complete
+            # sequence.
+            # Commit the whole cache if writing is enabled.
+            if write_cache_state is not None:
+                # TODO: Do a full pages write or a single row write, depending
+                # on whether prefill vs decode.
+                if read_cache_state is None:
+                    # Overwrite the whole cache.
+                    cache.write(
+                        write_cache_state,
+                        cache_partitions=[xk_cache_update, xv_cache_update],
+                        transformer_block_index=self.block_index,
+                        page_ids=seq_block_ids,
+                    )
+            return xk_cache_update, xv_cache_update
+        else:
+            # We need to initialize/read the K/V from the cache for the whole
+            # sequence. Note that at this point, it is possible to fork and
+            # use a memory efficient attention kernel that can do indirect
+            # reads, skipping this materialization. This path is taken for
+            # a decode step.
+            assert start_positions is not None
+            assert xk_temp is not None and xv_temp is not None
+
+            kv_seq_len = seq_block_ids.shape[1] * cache.block_seq_stride
+
+            if write_cache_state:
+                # Write our one updated cache row into the cache.
+                cache.write_timestep(
+                    write_cache_state,
+                    cache_partitions=[
+                        xk_cache_update,
+                        xv_cache_update,
+                    ],
+                    transformer_block_index=self.block_index,
+                    seq_positions=start_positions + 1,
+                    page_ids=seq_block_ids,
+                )
+
+            # Restore from the cache.
+            cache.read(
+                read_cache_state,
+                read_into_partitions=[
+                    xk_temp[:, 0:kv_seq_len, ...],
+                    xv_temp[:, 0:kv_seq_len, ...],
+                ],
+                transformer_block_index=self.block_index,
+                page_ids=seq_block_ids,
+            )
+
+            # For computation, we create a subview of the xk/xv tensors to have
+            # a sequence length covering the blocked size. This must include
+            # the newly added row (the caller is responsible for ensuring that
+            # every block has at least one row left). We'll compute on this
+            # ragged view and use an appropriate mask.
+            xk = xk_temp[:, 0:kv_seq_len, ...]
+            xv = xv_temp[:, 0:kv_seq_len, ...]
+            return xk, xv


### PR DESCRIPTION
I still want to do more work on configs and how to construct models, but this at least unifies the implementations for paged and direct.