### PR TITLE
Fix assert on `aot.export()` with CompiledModule subclasses.

### DIFF
--- a/core/shark_turbine/aot/exporter.py
+++ b/core/shark_turbine/aot/exporter.py
@@ -26,7 +26,6 @@ from ..support.ir_imports import (
 from .builtins import *
 from .compiled_module import (
     CompiledModule,
-    CompiledModuleMeta,
     ImportPhase,
 )
 from .fx_programs import FxPrograms
@@ -283,7 +282,7 @@ def export(
             {(function_name or "main"): exported_program},
             export_name=module_name or "module",
         )
-    elif issubclass(type(mdl), CompiledModuleMeta):
+    elif issubclass(mdl, CompiledModule):
         TransformedModule = mdl
     else:
         raise TypeError(f"mdl argument (type: {type(mdl)}) is not a supported type")

--- a/core/shark_turbine/aot/exporter.py
+++ b/core/shark_turbine/aot/exporter.py
@@ -26,6 +26,7 @@ from ..support.ir_imports import (
 from .builtins import *
 from .compiled_module import (
     CompiledModule,
+    CompiledModuleMeta,
     ImportPhase,
 )
 from .fx_programs import FxPrograms
@@ -282,9 +283,10 @@ def export(
             {(function_name or "main"): exported_program},
             export_name=module_name or "module",
         )
-    else:
-        assert issubclass(type(mdl), CompiledModule)
+    elif issubclass(type(mdl), CompiledModuleMeta):
         TransformedModule = mdl
+    else:
+        raise TypeError(f"mdl argument (type: {type(mdl)}) is not a supported type")
 
     session = Session()
     # There are some bugs with respect to Session/context interop that we

--- a/core/tests/aot/api_test.py
+++ b/core/tests/aot/api_test.py
@@ -120,7 +120,8 @@ class ExportAPI(unittest.TestCase):
         )
 
     def testCompiledModuleExportedProgram(self):
-        class BasicModule(CompiledModule): ...
+        class BasicModule(CompiledModule):
+            ...
 
         exported = export(BasicModule)
         module_str = str(exported.mlir_module)
@@ -128,7 +129,8 @@ class ExportAPI(unittest.TestCase):
         self.assertIn("module @basic", module_str)
 
     def testUnsupportedExportedProgram(self):
-        class UnsupportedExportType: ...
+        class UnsupportedExportType:
+            ...
 
         with self.assertRaises(TypeError):
             export(UnsupportedExportType)

--- a/core/tests/aot/api_test.py
+++ b/core/tests/aot/api_test.py
@@ -119,6 +119,20 @@ class ExportAPI(unittest.TestCase):
             asm,
         )
 
+    def testCompiledModuleExportedProgram(self):
+        class BasicModule(CompiledModule): ...
+
+        exported = export(BasicModule)
+        module_str = str(exported.mlir_module)
+        print(module_str)
+        self.assertIn("module @basic", module_str)
+
+    def testUnsupportedExportedProgram(self):
+        class UnsupportedExportType: ...
+
+        with self.assertRaises(TypeError):
+            export(UnsupportedExportType)
+
 
 class SimpleParams(nn.Module):
     def __init__(self):


### PR DESCRIPTION
I was hitting an assert trying to pass a subclass of `CompiledModule` through the `aot.export()` API. The code looked correct, but the metaclass code here: https://github.com/nod-ai/SHARK-Turbine/blob/b22dc7f77cab3bc7a7e29ae73398468799edf713/core/shark_turbine/aot/compiled_module.py#L429 could be affecting the check. I looked through https://stackoverflow.com/questions/33347131/determine-if-a-class-in-python-is-a-metaclass for ideas on how to fix.