### PR TITLE
Documentation touchups to README and package files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # SHARK Turbine
+
 ![image](https://netl.doe.gov/sites/default/files/2020-11/Turbine-8412270026_83cfc8ee8f_c.jpg)
 
 Turbine is the set of development tools that the [SHARK Team](https://github.com/nod-ai/SHARK)
 is building for deploying all of our models for deployment to the cloud and devices. We
-are building it as we transition from our TorchScript-era 1-off export and compilation 
-to a unified approach based on PyTorch 2 and Dynamo. While we use it heavily ourselves, it 
+are building it as we transition from our TorchScript-era 1-off export and compilation
+to a unified approach based on PyTorch 2 and Dynamo. While we use it heavily ourselves, it
 is intended to be a general purpose model compilation and execution tool.
 
-Turbine provides three primary tools:
+Turbine provides a collection of tools:
 
 * *AOT Export*: For compiling one or more `nn.Module`s to compiled, deployment
   ready artifacts. This operates via both a simple one-shot export API (Already upstreamed to [torch-mlir](https://github.com/llvm/torch-mlir/blob/main/python/torch_mlir/extras/fx_importer.py))
@@ -20,6 +21,8 @@ Turbine provides three primary tools:
   native PyTorch constructs and tracing. It is intended to complement for simple
   cases where direct emission to the underlying, cross platform, vector programming model
   is desirable.
+* *Turbine-LLM*: a repository of layers, model recipes, and conversion tools
+  from popular Large Language Model (LLM) quantization tooling.
 
 Under the covers, Turbine is based heavily on [IREE](https://github.com/openxla/iree) and
 [torch-mlir](https://github.com/llvm/torch-mlir) and we use it to drive evolution
@@ -30,7 +33,7 @@ See [the roadmap](docs/roadmap.md) for upcoming work and places to contribute.
 ## Contact Us
 
 Turbine is under active development. If you would like to participate as it comes online,
-please reach out to us on the `#turbine` channel of the 
+please reach out to us on the `#turbine` channel of the
 [nod-ai Discord server](https://discord.gg/QMmR6f8rGb).
 
 ## Quick Start for Users
@@ -53,7 +56,7 @@ pip install shark-turbine
 
 2. Try one of the samples:
 
-Generally, we use Turbine to produce valid, dynamic shaped Torch IR (from the 
+Generally, we use Turbine to produce valid, dynamic shaped Torch IR (from the
 [`torch-mlir torch` dialect](https://github.com/llvm/torch-mlir/tree/main/include/torch-mlir/Dialect/Torch/IR)
 with various approaches to handling globals). Depending on the use-case and status of the
 compiler, these should be compilable via IREE with `--iree-input-type=torch` for
@@ -102,8 +105,8 @@ If doing native development of the compiler, it can be useful to switch to
 source builds for iree-compiler and iree-runtime.
 
 In order to do this, check out [IREE](https://github.com/openxla/iree) and
-follow the instructions to [build from source](https://openxla.github.io/iree/building-from-source/getting-started/#configuration-settings), making
-sure to specify [additional options](https://openxla.github.io/iree/building-from-source/getting-started/#building-with-cmake):
+follow the instructions to [build from source](https://iree.dev/building-from-source/getting-started/), making
+sure to specify [additional options for the Python bindings](https://iree.dev/building-from-source/getting-started/#building-with-cmake):
 
 ```
 -DIREE_BUILD_PYTHON_BINDINGS=ON -DPython3_EXECUTABLE="$(which python)"
@@ -117,6 +120,7 @@ Uninstall existing packages:
 pip uninstall iree-compiler
 pip uninstall iree-runtime
 ```
+
 Copy the `.env` file from `iree/` to this source directory to get IDE
 support and add to your path for use from your shell:
 

--- a/core/README.md
+++ b/core/README.md
@@ -1,9 +1,10 @@
 # Turbine-Core Sub-Project
 
-This directory contains the core infrastructure for the project, sonsisting
+This directory contains the core infrastructure for the project, consisting
 of the model export, runtime, and kernel development APIs. It is packaged
-and released as the 
-[`SHARK-Turbine` project on PyPi](https://pypi.org/project/shark-turbine/).
+and released as the
+[`iree-turbine` project on PyPI](https://pypi.org/project/iree-turbine/)
+(previously [`SHARK-Turbine`](https://pypi.org/project/shark-turbine/)).
 
 It depends purely on PyTorch and the IREE compiler/runtime.
 

--- a/core/iree/turbine/__init__.py
+++ b/core/iree/turbine/__init__.py
@@ -1,3 +1,8 @@
+"""
+The turbine package provides development tools for deploying PyTorch 2 machine
+learning models to cloud and edge devices.
+"""
+
 # Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.

--- a/core/setup.py
+++ b/core/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Stella Laurenzo
+# Copyright 2023 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/core/shark_turbine/aot/__init__.py
+++ b/core/shark_turbine/aot/__init__.py
@@ -1,3 +1,7 @@
+"""
+Toolkit for ahead-of-time (AOT) compilation and export of PyTorch programs.
+"""
+
 # Copyright 2023 Nod Labs, Inc
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
Miscellaneous changes found from scanning some of the files. More to come, especially with the `shark-turbine` -> `iree-turbine` switch in progress.

---

The `__init__.py` changes add descriptions when using `help()` in Python, e.g.

```python
>>> help(iree.turbine)
Help on package iree.turbine in iree:

NAME
    iree.turbine

DESCRIPTION
    The turbine package provides development tools for deploying PyTorch 2 machine
    learning models to cloud and edge devices.
```

```python
>>> import shark_turbine.aot as aot
>>> help(aot)
Help on package shark_turbine.aot in shark_turbine:

NAME
    shark_turbine.aot - Toolkit for ahead-of-time (AOT) compilation and export of PyTorch programs.

PACKAGE CONTENTS
    builtins (package)
    compiled_module
    decompositions
    exporter
    fx_programs
    params
    passes (package)
    tensor_traits
```

Without those changes, packages include the license header 🤦 
```python
DESCRIPTION
    # Copyright 2023 Nod Labs, Inc
    #
    # Licensed under the Apache License v2.0 with LLVM Exceptions.
    # See https://llvm.org/LICENSE.txt for license information.
    # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
```