### PR TITLE
Update IREE pip-release-links URL.

### DIFF
--- a/build_tools/build_release.py
+++ b/build_tools/build_release.py
@@ -114,7 +114,7 @@ def download_iree_binaries():
         args.extend(platform_args)
         args += [
             "-f",
-            "https://openxla.github.io/iree/pip-release-links.html",
+            "https://iree.dev/pip-release-links.html",
             "-f",
             WHEEL_DIR,
             "-r",

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -2,7 +2,7 @@
 # setup with pinned deps and will fulfill all install
 # requirements for the package (which pins to minimum
 # versions, not specific).
--f https://openxla.github.io/iree/pip-release-links.html
+-f https://iree.dev/pip-release-links.html
 
 -r pytorch-requirements.txt
 -r iree-requirements.txt


### PR DESCRIPTION
The `openxla.github.io` link depends on a specific GitHub organization, and the IREE repo will be moving soon (multiple times). The `iree.dev` release links URL is recommended here: https://iree.dev/reference/bindings/python/#prebuilt-packages