### PR TITLE
Changes so that the default run without quant docker will work as well with all the new changes.

### DIFF
--- a/models/turbine_models/custom_models/sd_inference/sd_pipeline.py
+++ b/models/turbine_models/custom_models/sd_inference/sd_pipeline.py
@@ -236,6 +236,7 @@ class SharkSDPipeline(TurbinePipelineBase):
         batch_prompts: bool = False,
         punet_quant_paths: dict[str] = None,
         vae_weight_path: str = None,
+        vae_harness: bool = False,
     ):
         common_export_args = {
             "hf_model_name": None,
@@ -345,6 +346,7 @@ class SharkSDPipeline(TurbinePipelineBase):
             self.scheduler_target = self.map["unet"]["target"]
             if vae_weight_path is not None:
                 self.map["vae"]["export_args"]["external_weight_path"] = vae_weight_path
+            self.map["vae"]["export_args"]["vae_harness"] = vae_harness
         elif not self.is_sd3:
             self.tokenizer = CLIPTokenizer.from_pretrained(
                 self.base_model_name, subfolder="tokenizer"

--- a/models/turbine_models/custom_models/sd_inference/utils.py
+++ b/models/turbine_models/custom_models/sd_inference/utils.py
@@ -396,6 +396,7 @@ def save_external_weights(
             mod_params.update(mod_buffers)
             for name in mod_params:
                 if vae_harness:
+                    print(name)
                     name = name.replace("vae.", "")
                 mapper["params." + name] = name
             if external_weight_file and not os.path.isfile(external_weight_file):

--- a/models/turbine_models/custom_models/sd_inference/utils.py
+++ b/models/turbine_models/custom_models/sd_inference/utils.py
@@ -394,10 +394,13 @@ def save_external_weights(
             mod_params = dict(model.named_parameters())
             mod_buffers = dict(model.named_buffers())
             mod_params.update(mod_buffers)
+            vae_params = {}
             for name in mod_params:
                 if vae_harness:
-                    name = name.replace("vae.", "")
+                    vae_params[name.replace("vae.", "")] = mod_params[name]
                 mapper["params." + name] = name
+            if vae_harness:
+                mod_params = vae_params
             if external_weight_file and not os.path.isfile(external_weight_file):
                 if not force_format:
                     safetensors.torch.save_file(mod_params, external_weight_file)

--- a/models/turbine_models/custom_models/sd_inference/utils.py
+++ b/models/turbine_models/custom_models/sd_inference/utils.py
@@ -396,7 +396,6 @@ def save_external_weights(
             mod_params.update(mod_buffers)
             for name in mod_params:
                 if vae_harness:
-                    print(name)
                     name = name.replace("vae.", "")
                 mapper["params." + name] = name
             if external_weight_file and not os.path.isfile(external_weight_file):

--- a/models/turbine_models/custom_models/sd_inference/utils.py
+++ b/models/turbine_models/custom_models/sd_inference/utils.py
@@ -387,6 +387,7 @@ def save_external_weights(
     external_weights=None,
     external_weight_file=None,
     force_format=False,
+    vae_harness=False,
 ):
     if external_weights is not None:
         if external_weights in ["safetensors", "irpa"]:
@@ -394,6 +395,8 @@ def save_external_weights(
             mod_buffers = dict(model.named_buffers())
             mod_params.update(mod_buffers)
             for name in mod_params:
+                if vae_harness:
+                    name = name.replace("vae.", "")
                 mapper["params." + name] = name
             if external_weight_file and not os.path.isfile(external_weight_file):
                 if not force_format:

--- a/models/turbine_models/custom_models/sd_inference/vae.py
+++ b/models/turbine_models/custom_models/sd_inference/vae.py
@@ -119,7 +119,6 @@ def export_vae_model(
     input_mlir=None,
     weights_only=False,
     upload_ir=False,
-    vae_harness=False,
 ):
     dtype = torch.float16 if precision == "fp16" else torch.float32
     np_dtype = "float16" if precision == "fp16" else "float32"
@@ -164,7 +163,7 @@ def export_vae_model(
         vae_model = vae_model.half()
     mapper = {}
     utils.save_external_weights(
-        mapper, vae_model, external_weights, external_weight_path, vae_harness
+        mapper, vae_model, external_weights, external_weight_path
     )
     if weights_only:
         return external_weight_path

--- a/models/turbine_models/custom_models/sd_inference/vae.py
+++ b/models/turbine_models/custom_models/sd_inference/vae.py
@@ -119,6 +119,7 @@ def export_vae_model(
     input_mlir=None,
     weights_only=False,
     upload_ir=False,
+    vae_harness=False,
 ):
     dtype = torch.float16 if precision == "fp16" else torch.float32
     np_dtype = "float16" if precision == "fp16" else "float32"
@@ -163,7 +164,7 @@ def export_vae_model(
         vae_model = vae_model.half()
     mapper = {}
     utils.save_external_weights(
-        mapper, vae_model, external_weights, external_weight_path
+        mapper, vae_model, external_weights, external_weight_path, vae_harness
     )
     if weights_only:
         return external_weight_path

--- a/models/turbine_models/custom_models/sd_inference/vae.py
+++ b/models/turbine_models/custom_models/sd_inference/vae.py
@@ -119,6 +119,7 @@ def export_vae_model(
     input_mlir=None,
     weights_only=False,
     upload_ir=False,
+    vae_harness=False,
 ):
     dtype = torch.float16 if precision == "fp16" else torch.float32
     np_dtype = "float16" if precision == "fp16" else "float32"
@@ -162,9 +163,10 @@ def export_vae_model(
     if dtype == torch.float16:
         vae_model = vae_model.half()
     mapper = {}
-    utils.save_external_weights(
-        mapper, vae_model, external_weights, external_weight_path
-    )
+    if not os.path.exists(external_weight_path):
+        utils.save_external_weights(
+            mapper, vae_model, external_weights, external_weight_path, vae_harness=vae_harness
+        )
     if weights_only:
         return external_weight_path
 

--- a/models/turbine_models/custom_models/sdxl_inference/unet.py
+++ b/models/turbine_models/custom_models/sdxl_inference/unet.py
@@ -103,7 +103,7 @@ def get_punet_model(hf_model_name, external_weight_path, quant_paths, precision=
             repo_id=repo_id, subfolder=subfolder, filename=filename, revision=revision
         )
     
-    if quant_paths and quant_paths["config.json"] and os.path.exists(quant_paths["config.json"]):
+    if quant_paths and quant_paths["config"] and os.path.exists(quant_paths["config"]):
         results = {
             "config.json": quant_paths["config"],
         }
@@ -120,7 +120,7 @@ def get_punet_model(hf_model_name, external_weight_path, quant_paths, precision=
     output_dir = os.path.dirname(external_weight_path)
 
     if precision == "i8":
-        if quant_paths and quant_paths["quant_params.json"] and os.path.exists(quant_paths["quant_params.json"]):
+        if quant_paths and quant_paths["quant_params"] and os.path.exists(quant_paths["quant_params"]):
             results["quant_params.json"] = quant_paths["quant_params"]
         else:
             results["quant_params.json"] = download("quant_params.json")

--- a/models/turbine_models/custom_models/sdxl_inference/unet.py
+++ b/models/turbine_models/custom_models/sdxl_inference/unet.py
@@ -102,21 +102,25 @@ def get_punet_model(hf_model_name, external_weight_path, quant_paths, precision=
         return hf_hub_download(
             repo_id=repo_id, subfolder=subfolder, filename=filename, revision=revision
         )
-
-    if not quant_paths:
+    
+    if quant_paths and quant_paths["config.json"] and os.path.exists(quant_paths["config.json"]):
         results = {
-            "config.json": download("config.json"),
-            "params.safetensors": download("params.safetensors"),
+            "config.json": quant_paths["config"],
         }
     else:
         results = {
-            "config.json": quant_paths["config"],
-            "params.safetensors": quant_paths["params"],
+            "config.json": download("config.json"),
         }
+
+    if quant_paths and quant_paths["params"] and os.path.exists(quant_paths["params"]):
+        results["params.safetensors"] = quant_paths["params"]
+    else:
+        results["params.safetensors"] = download("params.safetensors")
+
     output_dir = os.path.dirname(external_weight_path)
 
     if precision == "i8":
-        if quant_paths:
+        if quant_paths and quant_paths["quant_params.json"] and os.path.exists(quant_paths["quant_params.json"]):
             results["quant_params.json"] = quant_paths["quant_params"]
         else:
             results["quant_params.json"] = download("quant_params.json")

--- a/models/turbine_models/custom_models/sdxl_inference/vae.py
+++ b/models/turbine_models/custom_models/sdxl_inference/vae.py
@@ -86,7 +86,6 @@ def export_vae_model(
     attn_spec=None,
     input_mlir=None,
     weights_only=False,
-    vae_harness=False,
 ):
     safe_name = utils.create_safe_name(
         hf_model_name,
@@ -122,7 +121,7 @@ def export_vae_model(
 
     if not os.path.exists(external_weight_path):
         utils.save_external_weights(
-            mapper, vae_model, external_weights, external_weight_path, vae_harness
+            mapper, vae_model, external_weights, external_weight_path
         )
     if weights_only:
         return external_weight_path

--- a/models/turbine_models/custom_models/sdxl_inference/vae.py
+++ b/models/turbine_models/custom_models/sdxl_inference/vae.py
@@ -86,6 +86,7 @@ def export_vae_model(
     attn_spec=None,
     input_mlir=None,
     weights_only=False,
+    vae_harness=False,
 ):
     safe_name = utils.create_safe_name(
         hf_model_name,
@@ -121,7 +122,7 @@ def export_vae_model(
 
     if not os.path.exists(external_weight_path):
         utils.save_external_weights(
-            mapper, vae_model, external_weights, external_weight_path
+            mapper, vae_model, external_weights, external_weight_path, vae_harness
         )
     if weights_only:
         return external_weight_path


### PR DESCRIPTION
This PR makes the necessary changes so that you don't have to run the quantization docker to run the normal harness. With stricter checks for the quant paths and adding a special switch to the save_external_weights so that it is compliant with this change that we need for the docker generated weights https://github.com/iree-org/iree-turbine/commit/cd916ec7aec3e9fcc91898a3b6b93e575148e3f3.